### PR TITLE
Various feats 1

### DIFF
--- a/USca/DbManager/Tags/AddTag.xaml
+++ b/USca/DbManager/Tags/AddTag.xaml
@@ -14,6 +14,7 @@
 
 	<Window.Resources>
 		<util:EnumToBooleanConverter x:Key="EnumToBoolConv" />
+		<util:BoolInverterConverter x:Key="BoolInverterConv" />
 	</Window.Resources>
 
 	<Grid Margin="10">
@@ -153,6 +154,19 @@
 								  SelectedItem="{Binding TagData.Unit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 					</Grid>
 				</GroupBox>
+                <GroupBox Header="Scanning">
+                    <StackPanel Orientation="Horizontal">
+                        <RadioButton
+                            Margin="0,0,15,0"
+                            Content="On"
+                            GroupName="Scanning"
+                            IsChecked="{Binding TagData.IsScanning, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <RadioButton
+                            Content="Off"
+                            GroupName="Scanning"
+                            IsChecked="{Binding TagData.IsScanning, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolInverterConv}}" />
+                    </StackPanel>
+                </GroupBox>
 			</StackPanel>
 		</Grid>
 

--- a/USca/DbManager/Tags/AddTag.xaml
+++ b/USca/DbManager/Tags/AddTag.xaml
@@ -8,7 +8,7 @@
 		mc:Ignorable="d"
 		Title="Create a new tag"
 		Width="450"
-		Height="360"
+		Height="380"
 		WindowStartupLocation="CenterOwner"
 		DataContext="{Binding RelativeSource={RelativeSource Self}}">
 

--- a/USca/DbManager/Tags/TagAddDTO.cs
+++ b/USca/DbManager/Tags/TagAddDTO.cs
@@ -25,5 +25,6 @@ namespace USca_DbManager.Tags
         public double Max { get; set; } = 10.0;
         public string Unit { get; set; } = "";
         public int ScanTime { get; set; } = 1000;
+        public bool IsScanning { get; set; } = true;
     }
 }

--- a/USca/DbManager/Tags/TagDTO.cs
+++ b/USca/DbManager/Tags/TagDTO.cs
@@ -14,5 +14,6 @@ namespace USca_DbManager.Tags
         public double Max { get; set; } = 10.0;
         public string Unit { get; set; } = "";
         public int ScanTime { get; set; } = 1000;
+        public bool IsScanning { get; set; } = true;
     }
 }

--- a/USca/DbManager/Tags/TagsDashboard.xaml
+++ b/USca/DbManager/Tags/TagsDashboard.xaml
@@ -98,6 +98,21 @@
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
+                <DataGridTemplateColumn Header="Scanning">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock x:Name="TextHolder" />
+                            <DataTemplate.Triggers>
+                                <DataTrigger Binding="{Binding IsScanning}" Value="true">
+                                    <Setter TargetName="TextHolder" Property="Text" Value="On" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding IsScanning}" Value="false">
+                                    <Setter TargetName="TextHolder" Property="Text" Value="Off" />
+                                </DataTrigger>
+                            </DataTemplate.Triggers>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
 			</DataGrid.Columns>
 		</DataGrid>
 

--- a/USca/DbManager/Util/Converters.cs
+++ b/USca/DbManager/Util/Converters.cs
@@ -22,4 +22,24 @@ namespace USca_DbManager.Util
             return parameter;
         }
     }
+    public class BoolInverterConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is bool val)
+            {
+                return !val;
+            }
+            return value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is bool val)
+            {
+                return !val;
+            }
+            return value;
+        }
+    }
 }

--- a/USca/USca-Server/Shared/ServerDbContext.cs
+++ b/USca/USca-Server/Shared/ServerDbContext.cs
@@ -19,15 +19,19 @@ namespace USca_Server.Shared
                 _created = true;
                 Database.EnsureDeleted();
                 Database.EnsureCreated();
-            }
-
-            if (Users != null)
-            {
-                Users.Add(new() { Name = "Bob", Surname = "Jones", Username = "user1", Password = "1234" });
-                Users.Add(new() { Name = "Bab", Surname = "Janes", Username = "user2", Password = "1234" });
-                Users.Add(new() { Name = "Bib", Surname = "Jines", Username = "user3", Password = "1234" });
+                LoadInitialData();
             }
             SaveChanges();
+        }
+
+        private void LoadInitialData()
+        {
+            Users.Add(new() { Name = "Bob", Surname = "Jones", Username = "user1", Password = "1234" });
+            Users.Add(new() { Name = "Bab", Surname = "Janes", Username = "user2", Password = "1234" });
+            Users.Add(new() { Name = "Bib", Surname = "Jines", Username = "user3", Password = "1234" });
+
+            Tags.Add(new() { Address = 1, Name = "Tag 1" });
+            Tags.Add(new() { Address = 2, Name = "Tag 2" });
         }
 
 		protected override void OnConfiguring(DbContextOptionsBuilder options)

--- a/USca/USca-Server/Shared/ServerDbContext.cs
+++ b/USca/USca-Server/Shared/ServerDbContext.cs
@@ -30,8 +30,10 @@ namespace USca_Server.Shared
             Users.Add(new() { Name = "Bab", Surname = "Janes", Username = "user2", Password = "1234" });
             Users.Add(new() { Name = "Bib", Surname = "Jines", Username = "user3", Password = "1234" });
 
-            Tags.Add(new() { Address = 1, Name = "Tag 1" });
-            Tags.Add(new() { Address = 2, Name = "Tag 2" });
+            Tags.Add(new() { Address = 1, Name = "Tank01" });
+            Tags.Add(new() { Address = 2, Name = "Tank01_ValveIn" });
+            Tags.Add(new() { Address = 3, Name = "Tank01_ValveIn_Reserve" });
+            Tags.Add(new() { Address = 4, Name = "Tank01_ValveOut" });
         }
 
 		protected override void OnConfiguring(DbContextOptionsBuilder options)

--- a/USca/USca-Server/Shared/ServerDbContext.cs
+++ b/USca/USca-Server/Shared/ServerDbContext.cs
@@ -33,10 +33,42 @@ namespace USca_Server.Shared
             Users.Add(new() { Name = "Bab", Surname = "Janes", Username = "user2", Password = "1234" });
             Users.Add(new() { Name = "Bib", Surname = "Jines", Username = "user3", Password = "1234" });
 
-            Tags.Add(new() { Address = 1, Name = "Tank01" });
-            Tags.Add(new() { Address = 2, Name = "Tank01_ValveIn" });
-            Tags.Add(new() { Address = 3, Name = "Tank01_ValveIn_Reserve" });
-            Tags.Add(new() { Address = 4, Name = "Tank01_ValveOut" });
+            Tags.Add(new()
+            {
+                Address = 1,
+                Name = "Tank01",
+                Type = TagType.Analog,
+                Unit = "litre",
+                Min = 0,
+                Max = 10,
+            });
+            Tags.Add(new() 
+            {
+                Address = 2,
+                Name = "Tank01_ValveIn",
+                Type = TagType.Analog,
+                Unit = "litre",
+                Min = 0,
+                Max = 1,
+            });
+            Tags.Add(new()
+            { 
+                Address = 3,
+                Name = "Tank01_ValveIn_Reserve",
+                Type = TagType.Analog,
+                Unit = "litre",
+                Min = 0,
+                Max = 1,
+            });
+            Tags.Add(new() 
+            { 
+                Address = 4,
+                Name = "Tank01_ValveOut",
+                Type = TagType.Analog,
+                Unit = "litre",
+                Min = 0,
+                Max = 1,
+            });
 
             SaveChanges();
         }

--- a/USca/USca-Server/Shared/ServerDbContext.cs
+++ b/USca/USca-Server/Shared/ServerDbContext.cs
@@ -12,14 +12,18 @@ namespace USca_Server.Shared
 		public DbSet<Tag> Tags { get; set; }
 
 		private static bool _created = false;
+        private static readonly object _lock = new();
         public ServerDbContext()
         {
-            if (!_created)
+            lock (_lock)
             {
-                _created = true;
-                Database.EnsureDeleted();
-                Database.EnsureCreated();
-                LoadInitialData();
+                if (!_created)
+                {
+                    _created = true;
+                    Database.EnsureDeleted();
+                    Database.EnsureCreated();
+                    LoadInitialData();
+                }
             }
             SaveChanges();
         }

--- a/USca/USca-Server/Shared/ServerDbContext.cs
+++ b/USca/USca-Server/Shared/ServerDbContext.cs
@@ -25,7 +25,6 @@ namespace USca_Server.Shared
                     LoadInitialData();
                 }
             }
-            SaveChanges();
         }
 
         private void LoadInitialData()
@@ -38,6 +37,8 @@ namespace USca_Server.Shared
             Tags.Add(new() { Address = 2, Name = "Tank01_ValveIn" });
             Tags.Add(new() { Address = 3, Name = "Tank01_ValveIn_Reserve" });
             Tags.Add(new() { Address = 4, Name = "Tank01_ValveOut" });
+
+            SaveChanges();
         }
 
 		protected override void OnConfiguring(DbContextOptionsBuilder options)

--- a/USca/USca-Server/Tags/Tag.cs
+++ b/USca/USca-Server/Tags/Tag.cs
@@ -27,6 +27,7 @@ namespace USca_Server.Tags
         public double Max { get; set; } = 10.0;
         public string Unit { get; set; } = "";
         public int ScanTime { get; set; } = 1000;
+        public bool IsScanning { get; set; } = true;
 
         public Tag()
         {
@@ -44,6 +45,7 @@ namespace USca_Server.Tags
             Max = dto.Max;
             Unit = dto.Unit;
             ScanTime = dto.ScanTime;
+            IsScanning = dto.IsScanning;
         }
     }
 }

--- a/USca/USca-Server/Tags/TagAddDTO.cs
+++ b/USca/USca-Server/Tags/TagAddDTO.cs
@@ -11,5 +11,6 @@
         public double Max { get; set; } = 10.0;
         public string Unit { get; set; } = "";
         public int ScanTime { get; set; } = 1000;
+        public bool IsScanning { get; set; } = true;
     }
 }

--- a/USca/USca-Server/Tags/TagDTO.cs
+++ b/USca/USca-Server/Tags/TagDTO.cs
@@ -12,5 +12,6 @@
         public double Max { get; set; } = 10.0;
         public string Unit { get; set; } = "";
         public int ScanTime { get; set; } = 1000;
+        public bool IsScanning { get; set; } = true;
     }
 }

--- a/USca/USca-Server/Tags/TagTrendingWorker.cs
+++ b/USca/USca-Server/Tags/TagTrendingWorker.cs
@@ -135,19 +135,21 @@ namespace USca_Server.Tags
         {
             Thread.Sleep(t.ScanTime);
 
-            double value = 0;
             using (var db = new ServerDbContext())
             {
                 var measure = db.Measures.Find(t.Address);
                 if (measure != null)
                 {
-                    value = measure.Value;
-
                     var message = new
                     {
-                        TagID = t.Id,
-                        Address = t.Address,
-                        Value = value
+                        t.Id,
+                        t.Name,
+                        t.Type,
+                        t.Min,
+                        t.Max,
+                        t.Unit,
+                        measure.Value,
+                        measure.Timestamp,
                     };
                     var messageJson = JsonSerializer.Serialize(message);
 

--- a/USca/USca-Server/Tags/TagTrendingWorker.cs
+++ b/USca/USca-Server/Tags/TagTrendingWorker.cs
@@ -104,57 +104,10 @@ namespace USca_Server.Tags
                 {
                     _threads[tag.Id] = new(tag, Ws);
                     _threads[tag.Id].LoopThread.Start();
-                    Console.WriteLine($"Added thread for tag {tag}.");
+                    Console.WriteLine($"Added thread for tag {tag.Id}.");
                 } else
                 {
                     _threads[tag.Id].Tag = tag;
-                }
-            }
-        }
-
-        /// <summary>
-        /// This method tries to send current data from the tag <c>t</c> across the WebSocket.
-        /// This method should run in a <c>LoopThread</c> assigned to the given tag.
-        /// </summary>
-        private void SendTagData(Tag t)
-        {
-            Thread.Sleep(t.ScanTime);
-
-            using (var db = new ServerDbContext())
-            {
-                var measure = db.Measures.Find(t.Address);
-                if (measure != null)
-                {
-                    var message = new
-                    {
-                        t.Id,
-                        t.Name,
-                        t.Type,
-                        t.Min,
-                        t.Max,
-                        t.Unit,
-                        measure.Value,
-                        measure.Timestamp,
-                    };
-                    var messageJson = JsonSerializer.Serialize(message);
-
-                    try
-                    {
-                        Ws.SendAsync(
-                            new(Encoding.UTF8.GetBytes(messageJson)),
-                            WebSocketMessageType.Text,
-                            true,
-                            CancellationToken.None
-                        );
-                    }
-                    catch (WebSocketException)
-                    {
-                        // Client forcibly closed the socket.
-                    }
-                }
-                else
-                {
-                    // The tag points to a measure that doesn't exist.
                 }
             }
         }
@@ -193,6 +146,8 @@ namespace USca_Server.Tags
                         {
                             Tag.Id,
                             Tag.Name,
+                            Tag.Address,
+                            Tag.ScanTime,
                             Tag.Type,
                             Tag.Min,
                             Tag.Max,

--- a/USca/USca-Server/Tags/TagTrendingWorker.cs
+++ b/USca/USca-Server/Tags/TagTrendingWorker.cs
@@ -91,7 +91,7 @@ namespace USca_Server.Tags
             Console.WriteLine("Sync tags");
 
             var currentTags = _tagService.GetAll()
-                .Where(t => t.Mode == TagMode.Input)
+                .Where(t => t.Mode == TagMode.Input && t.IsScanning)
                 .Select(t => t.Id)
                 .ToList();
             var staleTags = _threads.Keys.ToList().Except(currentTags);

--- a/USca/USca-Server/Util/LoopThread.cs
+++ b/USca/USca-Server/Util/LoopThread.cs
@@ -7,7 +7,7 @@
     public class LoopThread
     {
         private Thread _thread { get; set; }
-        public bool _isRunning { get; set; } = true;
+        public bool IsRunning { get; set; } = true;
 
         public LoopThread(ThreadStart threadStart)
         {
@@ -17,7 +17,7 @@
 
         private void ThinWrapper(ThreadStart threadStart)
         {
-            while (_isRunning)
+            while (IsRunning)
             {
                 threadStart.Invoke();
             }
@@ -30,7 +30,7 @@
 
         public void Abort()
         {
-            _isRunning = false;
+            IsRunning = false;
         }
     }
 }

--- a/USca/USca-Server/Util/SocketMessageDTO.cs
+++ b/USca/USca-Server/Util/SocketMessageDTO.cs
@@ -1,0 +1,14 @@
+namespace USca_Server.Util
+{
+    public enum SocketMessageType
+    {
+        DELETE_TAG_READING,
+        UPDATE_TAG_READING,
+    }
+
+    public class SocketMessageDTO
+    {
+        public SocketMessageType Type { get; set; }
+        public string? Message { get; set; }
+    }
+}

--- a/USca/USca_RTU/MainWindow.xaml.cs
+++ b/USca/USca_RTU/MainWindow.xaml.cs
@@ -35,7 +35,7 @@ namespace USca_RTU
         {
             while (true)
             {
-                Thread.Sleep(500);
+                Thread.Sleep(250);
 
                 Simulator.Update();
                 _reader.Update();
@@ -48,7 +48,7 @@ namespace USca_RTU
         {
             while (true)
             {
-                Thread.Sleep(2000);
+                Thread.Sleep(250);
 
                 await CommService.SendSignalsBatch(_reader.Signals);
             }

--- a/USca/USca_RTU/Processor/Simulator.cs
+++ b/USca/USca_RTU/Processor/Simulator.cs
@@ -35,10 +35,15 @@ namespace USca_RTU.Processor
 	{
 		public int Id { get; set; } = -1;
 		public string Name { get; set; }
-		public double Value { get; set; } = 0;
-		public bool Open { get; set; } = true;
+        private double _value = 0;
+        public double Value
+        {
+            get { return Open ? _value : 0; }
+            set { _value = value; }
+        }
+        public bool Open { get; set; } = true;
 
-		public Valve(int id, string name, double startValue, bool open)
+    public Valve(int id, string name, double startValue, bool open)
 		{
 			Id = id;
 			Name = name;

--- a/USca/USca_RTU/Processor/Simulator.cs
+++ b/USca/USca_RTU/Processor/Simulator.cs
@@ -21,7 +21,12 @@ namespace USca_RTU.Processor
 	{
 		public int Id { get; set; } = -1;
 		public string Name { get; set; }
-		public double Value { get; set; } = 5;
+		private double _value = 5;
+		public double Value
+		{
+			get { return _value; }
+			set { _value = Math.Clamp(value, 0, ValueMax); }
+		}
 		public double ValueMax { get; set; } = 10;
 
 		public Tank(int id, string name)
@@ -39,7 +44,7 @@ namespace USca_RTU.Processor
         public double Value
         {
             get { return Open ? _value : 0; }
-            set { _value = value; }
+            set { _value = Math.Clamp(value, 0, Double.MaxValue); }
         }
         public bool Open { get; set; } = true;
 
@@ -124,7 +129,7 @@ namespace USca_RTU.Processor
 		{
 			foreach (var o in Valves)
 			{
-				o.Value += r.NextDouble() * Math.Sin(DateTime.Now.Ticks / 5.0 + r.NextDouble() * 0.0001) * 0.0001;
+				o.Value += Math.Abs(r.NextDouble() * Math.Sin(DateTime.Now.Ticks / 5.0 + r.NextDouble() * 0.0001) * 0.0001);
 			}
 
 			foreach (var o in TankValves)

--- a/USca/USca_Trending/Tags/InputTagReadingDTO.cs
+++ b/USca/USca_Trending/Tags/InputTagReadingDTO.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace USca_Trending.Tags
+{
+    public partial class InputTagReadingDTO: INotifyPropertyChanged
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+        public TagType Type { get; set; }
+        public double Min { get; set; }
+        public double Max { get; set; }
+        public string? Unit { get; set; }
+        public double Value { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/USca/USca_Trending/Tags/InputTagReadingDTO.cs
+++ b/USca/USca_Trending/Tags/InputTagReadingDTO.cs
@@ -11,6 +11,8 @@ namespace USca_Trending.Tags
     {
         public int Id { get; set; }
         public string? Name { get; set; }
+        public int Address { get; set; }
+        public double ScanTime { get; set; }
         public TagType Type { get; set; }
         public double Min { get; set; }
         public double Max { get; set; }

--- a/USca/USca_Trending/Tags/TagValues.xaml
+++ b/USca/USca_Trending/Tags/TagValues.xaml
@@ -57,7 +57,13 @@
                     </DataTemplate>
                 </DataGridTemplateColumn.CellTemplate>
             </DataGridTemplateColumn>
-            <DataGridTextColumn Binding="{Binding Value, StringFormat='#0.0000'}" Header="Value" />
+            <DataGridTextColumn Binding="{Binding Value, StringFormat={}{0:+#0.000000;-#0.000000;' 0'}}" Header="Value" >
+				<DataGridTextColumn.ElementStyle>
+					<Style TargetType="{x:Type TextBlock}">
+						<Setter Property="HorizontalAlignment" Value="Right" />
+					</Style>
+				</DataGridTextColumn.ElementStyle>
+			</DataGridTextColumn>
             <DataGridTextColumn Binding="{Binding Timestamp}" Header="Timestamp" />
         </DataGrid.Columns>
     </DataGrid>

--- a/USca/USca_Trending/Tags/TagValues.xaml
+++ b/USca/USca_Trending/Tags/TagValues.xaml
@@ -17,8 +17,9 @@
         IsReadOnly="True"
         ItemsSource="{Binding TagReadings}">
         <DataGrid.Columns>
-            <DataGridTextColumn Binding="{Binding Id}" Header="Id" />
             <DataGridTextColumn Binding="{Binding Name}" Header="Name" />
+            <DataGridTextColumn Binding="{Binding Address}" Header="Address" />
+            <DataGridTextColumn Binding="{Binding ScanTime}" Header="ScanTime" />
             <DataGridTextColumn Binding="{Binding Type}" Header="Type" />
             <DataGridTemplateColumn Header="Min">
                 <DataGridTemplateColumn.CellTemplate>

--- a/USca/USca_Trending/Tags/TagValues.xaml
+++ b/USca/USca_Trending/Tags/TagValues.xaml
@@ -1,12 +1,63 @@
-﻿<UserControl x:Class="USca_Trending.Tags.TagValues"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:USca_Trending.Tags"
-             mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="800">
-    <Grid>
-            
-    </Grid>
+﻿<UserControl
+    x:Class="USca_Trending.Tags.TagValues"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:USca_Trending.Tags"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    DataContext="{Binding RelativeSource={RelativeSource Self}}"
+    mc:Ignorable="d">
+    <DataGrid
+        x:Name="TbTags"
+        Grid.Row="0"
+        Margin="10"
+        AutoGenerateColumns="False"
+        IsReadOnly="True"
+        ItemsSource="{Binding TagReadings}">
+        <DataGrid.Columns>
+            <DataGridTextColumn Binding="{Binding Id}" Header="Id" />
+            <DataGridTextColumn Binding="{Binding Name}" Header="Name" />
+            <DataGridTextColumn Binding="{Binding Type}" Header="Type" />
+            <DataGridTemplateColumn Header="Min">
+                <DataGridTemplateColumn.CellTemplate>
+                    <DataTemplate>
+                        <TextBlock x:Name="TextHolder" Text="{Binding Min}" />
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding Type}" Value="{x:Static local:TagType.Digital}">
+                                <Setter TargetName="TextHolder" Property="Text" Value="-" />
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
+                    </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+            <DataGridTemplateColumn Header="Max">
+                <DataGridTemplateColumn.CellTemplate>
+                    <DataTemplate>
+                        <TextBlock x:Name="TextHolder" Text="{Binding Max}" />
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding Type}" Value="{x:Static local:TagType.Digital}">
+                                <Setter TargetName="TextHolder" Property="Text" Value="-" />
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
+                    </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+            <DataGridTemplateColumn Header="Unit">
+                <DataGridTemplateColumn.CellTemplate>
+                    <DataTemplate>
+                        <TextBlock x:Name="TextHolder" Text="{Binding Unit}" />
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding Type}" Value="{x:Static local:TagType.Digital}">
+                                <Setter TargetName="TextHolder" Property="Text" Value="-" />
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
+                    </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+            <DataGridTextColumn Binding="{Binding Value, StringFormat='#0.0000'}" Header="Value" />
+            <DataGridTextColumn Binding="{Binding Timestamp}" Header="Timestamp" />
+        </DataGrid.Columns>
+    </DataGrid>
 </UserControl>

--- a/USca/USca_Trending/Tags/TagValues.xaml.cs
+++ b/USca/USca_Trending/Tags/TagValues.xaml.cs
@@ -3,11 +3,17 @@ using System.Text;
 using System.Threading;
 using System;
 using System.Windows.Controls;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace USca_Trending.Tags
 {
     public partial class TagValues : UserControl
     {
+        public ObservableCollection<InputTagReadingDTO> TagReadings { get; set; } = new();
+
         public TagValues()
         {
             InitializeComponent();
@@ -31,9 +37,30 @@ namespace USca_Trending.Tags
                     else
                     {
                         // Get data...
-                        Console.WriteLine(Encoding.ASCII.GetString(buffer, 0, result.Count));
+                        var dtoJson = Encoding.ASCII.GetString(buffer, 0, result.Count);
+                        Console.WriteLine(dtoJson);
+                        LoadTagReading(JsonSerializer.Deserialize<InputTagReadingDTO>(dtoJson));
                     }
                 }
+            }
+        }
+
+        private void LoadTagReading(InputTagReadingDTO? dto)
+        {
+            if (dto == null)
+            {
+                return;
+            }
+            var item = TagReadings.FirstOrDefault(t => t.Id == dto.Id);
+            int idx =  (item != null) ? TagReadings.IndexOf(item) : -1;
+            Console.WriteLine($"idx {idx}");
+            if (idx == -1)
+            {
+                Console.WriteLine("Huh??");
+                TagReadings.Add(dto);
+            } else
+            {
+                TagReadings[idx] = dto;
             }
         }
     }

--- a/USca/USca_Trending/Tags/TagValues.xaml.cs
+++ b/USca/USca_Trending/Tags/TagValues.xaml.cs
@@ -38,7 +38,6 @@ namespace USca_Trending.Tags
                     {
                         // Get data...
                         var dtoJson = Encoding.ASCII.GetString(buffer, 0, result.Count);
-                        Console.WriteLine(dtoJson);
                         LoadTagReading(JsonSerializer.Deserialize<InputTagReadingDTO>(dtoJson));
                     }
                 }
@@ -53,10 +52,8 @@ namespace USca_Trending.Tags
             }
             var item = TagReadings.FirstOrDefault(t => t.Id == dto.Id);
             int idx =  (item != null) ? TagReadings.IndexOf(item) : -1;
-            Console.WriteLine($"idx {idx}");
             if (idx == -1)
             {
-                Console.WriteLine("Huh??");
                 TagReadings.Add(dto);
             } else
             {

--- a/USca/USca_Trending/Util/SocketMessageDTO.cs
+++ b/USca/USca_Trending/Util/SocketMessageDTO.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace USca_Trending.Util
+{
+    public enum SocketMessageType
+    {
+        DELETE_TAG_READING,
+        UPDATE_TAG_READING,
+    }
+
+    public class SocketMessageDTO
+    {
+        public SocketMessageType Type { get; set; }
+        public string? Message { get; set; }
+    }
+}


### PR DESCRIPTION
Closes #5, #8, #19

Considerations:
- Should `USca_Trending`'s `TagValues` be prettier? One idea is to flash the columns that changed to get the user's attention.
- Should we delete stale tag readings from `TagValues`? Currently, if we delete a tag in `DbManager`, the latest reading for the tag will remain. It's not clear to me if this is undesirable behavior.