### PR TITLE
Feat alarms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,3 +400,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Custom
+alarmLog.txt

--- a/USca/DbManager/Alarms/AddAlarm.xaml
+++ b/USca/DbManager/Alarms/AddAlarm.xaml
@@ -11,6 +11,7 @@
     Height="220"
     DataContext="{Binding RelativeSource={RelativeSource Self}}"
     ResizeMode="NoResize"
+    WindowStartupLocation="CenterOwner"
     mc:Ignorable="d">
     <Window.Resources>
         <util:EnumToBooleanConverter x:Key="EnumToBoolConv" />

--- a/USca/DbManager/Alarms/AddAlarm.xaml
+++ b/USca/DbManager/Alarms/AddAlarm.xaml
@@ -1,0 +1,105 @@
+﻿<Window
+    x:Class="USca_DbManager.Alarms.AddAlarm"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:USca_DbManager.Alarms"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:util="clr-namespace:USca_DbManager.Util"
+    Title="Create a new alarm"
+    Width="400"
+    Height="220"
+    DataContext="{Binding RelativeSource={RelativeSource Self}}"
+    ResizeMode="NoResize"
+    mc:Ignorable="d">
+    <Window.Resources>
+        <util:EnumToBooleanConverter x:Key="EnumToBoolConv" />
+        <util:TagDTOToCustomStringConverter x:Key="tagDTOToStringConv" />
+    </Window.Resources>
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="auto" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <StackPanel
+            Grid.Row="0"
+            Grid.Column="0"
+            Margin="0,0,10,0">
+            <Label Content="Threshold" />
+            <TextBox Text="{Binding Alarm.Threshold, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat='#0.0000'}" />
+        </StackPanel>
+        <StackPanel
+            Grid.Row="1"
+            Grid.Column="0"
+            Margin="0,0,10,0">
+            <Label Content="Tag" />
+            <ComboBox
+                ItemsSource="{Binding Tags}"
+                SelectedItem="{Binding SelectedTag}"
+                SelectionChanged="SelectedTag_Changed">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding {}, Converter={StaticResource tagDTOToStringConv}}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+        </StackPanel>
+        <GroupBox
+            Grid.Row="0"
+            Grid.Column="1"
+            Header="Threshold type">
+            <StackPanel>
+                <RadioButton
+                    Content="Below"
+                    GroupName="Threshold type"
+                    IsChecked="{Binding Alarm.ThresholdType, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource EnumToBoolConv}, ConverterParameter={x:Static local:AlarmThresholdType.BELOW}}" />
+                <RadioButton
+                    Content="Above"
+                    GroupName="Threshold type"
+                    IsChecked="{Binding Alarm.ThresholdType, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource EnumToBoolConv}, ConverterParameter={x:Static local:AlarmThresholdType.ABOVE}}" />
+            </StackPanel>
+        </GroupBox>
+        <GroupBox
+            Grid.Row="1"
+            Grid.Column="1"
+            Header="Priority">
+            <StackPanel>
+                <RadioButton
+                    Content="Low"
+                    GroupName="Priority"
+                    IsChecked="{Binding Alarm.Priority, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource EnumToBoolConv}, ConverterParameter={x:Static local:AlarmPriority.LOW}}" />
+                <RadioButton
+                    Content="Medium"
+                    GroupName="Priority"
+                    IsChecked="{Binding Alarm.Priority, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource EnumToBoolConv}, ConverterParameter={x:Static local:AlarmPriority.MEDIUM}}" />
+                <RadioButton
+                    Content="High"
+                    GroupName="Priority"
+                    IsChecked="{Binding Alarm.Priority, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource EnumToBoolConv}, ConverterParameter={x:Static local:AlarmPriority.HIGH}}" />
+            </StackPanel>
+        </GroupBox>
+        <StackPanel
+            Grid.Row="2"
+            Grid.ColumnSpan="2"
+            Margin="0,10,0,0"
+            HorizontalAlignment="Center"
+            Orientation="Horizontal">
+            <Button
+                Width="100"
+                Margin="0,0,10,0"
+                Click="BtnCancel_Click"
+                Content="Cancel" />
+            <Button
+                Width="100"
+                Click="BtnSave_Click"
+                Content="Save"
+                IsEnabled="{Binding CanSave}" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/USca/DbManager/Alarms/AddAlarm.xaml.cs
+++ b/USca/DbManager/Alarms/AddAlarm.xaml.cs
@@ -29,7 +29,7 @@ namespace USca_DbManager.Alarms
 
         private async void LoadTags(bool alarmLoaded)
         {
-            var tags = await TagService.GetAllTags();
+            var tags = await TagService.GetAnalogTags();
             Tags.Clear();
             tags.ForEach(Tags.Add);
             if (alarmLoaded)

--- a/USca/DbManager/Alarms/AddAlarm.xaml.cs
+++ b/USca/DbManager/Alarms/AddAlarm.xaml.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Text.Json;
+using System.Windows;
+using USca_DbManager.Tags;
+
+namespace USca_DbManager.Alarms
+{
+    /// <summary>
+    /// Interaction logic for AddAlarm.xaml
+    /// </summary>
+    public partial class AddAlarm : Window, INotifyPropertyChanged
+    {
+        public AlarmDTO Alarm { get; set; } = new();
+        public ObservableCollection<TagDTO> Tags { get; set; } = new();
+        public TagDTO? SelectedTag { get; set; }
+        public bool CanSave { get { return SelectedTag != null; } }
+
+        public AddAlarm(AlarmDTO? alarm = null)
+        {
+            InitializeComponent();
+            if (alarm != null)
+            {
+                Alarm = JsonSerializer.Deserialize<AlarmDTO>(JsonSerializer.Serialize(alarm)) ?? new();
+            }
+            LoadTags(alarm != null);
+        }
+
+        private async void LoadTags(bool alarmLoaded)
+        {
+            var tags = await TagService.GetAllTags();
+            Tags.Clear();
+            tags.ForEach(Tags.Add);
+            if (alarmLoaded)
+            {
+                SelectedTag = tags.Find(a => a.Id == Alarm.TagId) ?? null;
+            }
+        }
+
+        private void BtnCancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+
+        private void BtnSave_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+            Close();
+        }
+
+        private void SelectedTag_Changed(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            if (Alarm != null && SelectedTag != null)
+            {
+                Alarm.TagId = SelectedTag.Id;
+            }
+        }
+    }
+}

--- a/USca/DbManager/Alarms/AlarmDTO.cs
+++ b/USca/DbManager/Alarms/AlarmDTO.cs
@@ -1,8 +1,6 @@
-using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
-using USca_Server.Tags;
+﻿using System.ComponentModel;
 
-namespace USca_Server.Alarms
+namespace USca_DbManager.Alarms
 {
     public enum AlarmThresholdType
     {
@@ -17,20 +15,13 @@ namespace USca_Server.Alarms
         HIGH = 3,
     }
 
-    public class Alarm
+    public partial class AlarmDTO : INotifyPropertyChanged
     {
-        [Key]
         public int Id { get; set; }
-        [Required]
         public AlarmThresholdType ThresholdType { get; set; }
-        [Required]
         public AlarmPriority Priority { get; set; }
-        [Required]
         public double Threshold { get; set; }
-        [Required]
         public int TagId { get; set; }
-        [JsonIgnore]
-        public virtual Tag Tag { get; set; } = new();
 
         public override string ToString()
         {

--- a/USca/DbManager/Alarms/AlarmDTO.cs
+++ b/USca/DbManager/Alarms/AlarmDTO.cs
@@ -10,9 +10,9 @@ namespace USca_DbManager.Alarms
 
     public enum AlarmPriority
     {
-        LOW = 1,
-        MEDIUM = 2,
-        HIGH = 3,
+        LOW,
+        MEDIUM,
+        HIGH,
     }
 
     public partial class AlarmDTO : INotifyPropertyChanged

--- a/USca/DbManager/Alarms/AlarmService.cs
+++ b/USca/DbManager/Alarms/AlarmService.cs
@@ -1,0 +1,43 @@
+﻿using RestSharp;
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace USca_DbManager.Alarms
+{
+    internal class AlarmService
+    {
+        private static readonly string URL = "http://localhost:5274/api";
+
+        public static async Task<List<AlarmDTO>> GetAllAlarms()
+        {
+            using var cli = new RestClient(new RestClientOptions(URL));
+            var req = new RestRequest("alarm", Method.Get);
+            RestResponse response = await cli.ExecuteAsync(req);
+
+            if (response.StatusCode != System.Net.HttpStatusCode.OK)
+            {
+                throw new Exception(response.StatusCode.ToString());
+            }
+            if (response.Content == null)
+            {
+                return new();
+            }
+            var alarms = JsonSerializer.Deserialize<List<AlarmDTO>>(response.Content);
+            return alarms ?? new();
+        }
+
+        public static async Task DeleteAlarm(int alarmId)
+        {
+            using var cli = new RestClient(new RestClientOptions(URL));
+            var req = new RestRequest($"alarm/{alarmId}", Method.Delete);
+            RestResponse response = await cli.ExecuteAsync(req);
+
+            if (response.StatusCode != System.Net.HttpStatusCode.NoContent)
+            {
+                throw new Exception(response.StatusCode.ToString());
+            }
+        }
+    }
+}

--- a/USca/DbManager/Alarms/AlarmService.cs
+++ b/USca/DbManager/Alarms/AlarmService.cs
@@ -39,5 +39,31 @@ namespace USca_DbManager.Alarms
                 throw new Exception(response.StatusCode.ToString());
             }
         }
+
+        public static async Task AddAlarm(AlarmDTO alarmDTO)
+        {
+            using var cli = new RestClient(new RestClientOptions(URL));
+            var req = new RestRequest($"alarm", Method.Post);
+            req.AddBody(alarmDTO);
+            RestResponse response = await cli.ExecuteAsync(req);
+
+            if (response.StatusCode != System.Net.HttpStatusCode.NoContent)
+            {
+                throw new Exception(response.StatusCode.ToString());
+            }
+        }
+
+        public static async Task UpdateAlarm(AlarmDTO alarmDTO)
+        {
+            using var cli = new RestClient(new RestClientOptions(URL));
+            var req = new RestRequest($"alarm", Method.Put);
+            req.AddBody(alarmDTO);
+            RestResponse response = await cli.ExecuteAsync(req);
+
+            if (response.StatusCode != System.Net.HttpStatusCode.NoContent)
+            {
+                throw new Exception(response.StatusCode.ToString());
+            }
+        }
     }
 }

--- a/USca/DbManager/Alarms/AlarmsDashboard.xaml
+++ b/USca/DbManager/Alarms/AlarmsDashboard.xaml
@@ -1,0 +1,44 @@
+﻿<util:MyPage
+    x:Class="USca_DbManager.Alarms.AlarmsDashboard"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:USca_DbManager.Alarms"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:util="clr-namespace:USca_DbManager.Util"
+    Title="Alarms dashboard"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    DataContext="{Binding RelativeSource={RelativeSource Self}}"
+    mc:Ignorable="d">
+    <StackPanel>
+        <DataGrid
+            d:Height="400"
+            AutoGenerateColumns="False"
+            IsReadOnly="True"
+            ItemsSource="{Binding Alarms}"
+            MouseDoubleClick="TbAlarms_MouseDoubleClick"
+            SelectedItem="{Binding SelectedAlarm}">
+            <DataGrid.Columns>
+                <DataGridTextColumn Binding="{Binding Threshold}" Header="Threshold" />
+                <DataGridTextColumn Binding="{Binding ThresholdType}" Header="Threshold type" />
+                <DataGridTextColumn Binding="{Binding Priority}" Header="Priority" />
+                <DataGridTextColumn Binding="{Binding TagId}" Header="Tag ID" />
+            </DataGrid.Columns>
+        </DataGrid>
+        <StackPanel
+            Margin="5"
+            HorizontalAlignment="Right"
+            Orientation="Horizontal">
+            <Button
+                Width="100"
+                Margin="0,0,10,0"
+                Click="BtnDeleteAlarm_Click"
+                Content="Delete" />
+            <Button
+                Width="100"
+                Click="BtnAddAlarm_Click"
+                Content="Add" />
+        </StackPanel>
+    </StackPanel>
+</util:MyPage>

--- a/USca/DbManager/Alarms/AlarmsDashboard.xaml
+++ b/USca/DbManager/Alarms/AlarmsDashboard.xaml
@@ -7,19 +7,25 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:util="clr-namespace:USca_DbManager.Util"
     Title="Alarms dashboard"
+    Height="400"
     d:DesignHeight="450"
     d:DesignWidth="800"
     DataContext="{Binding RelativeSource={RelativeSource Self}}"
     mc:Ignorable="d">
-    <StackPanel>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition />
+            <RowDefinition Height="auto" />
+        </Grid.RowDefinitions>
         <DataGrid
-            d:Height="400"
+            Grid.Row="0"
             AutoGenerateColumns="False"
             IsReadOnly="True"
             ItemsSource="{Binding Alarms}"
             MouseDoubleClick="TbAlarms_MouseDoubleClick"
             SelectedItem="{Binding SelectedAlarm}">
             <DataGrid.Columns>
+                <DataGridTextColumn Binding="{Binding Id}" Header="Id" />
                 <DataGridTextColumn Binding="{Binding Threshold}" Header="Threshold" />
                 <DataGridTextColumn Binding="{Binding ThresholdType}" Header="Threshold type" />
                 <DataGridTextColumn Binding="{Binding Priority}" Header="Priority" />
@@ -27,6 +33,7 @@
             </DataGrid.Columns>
         </DataGrid>
         <StackPanel
+            Grid.Row="1"
             Margin="5"
             HorizontalAlignment="Right"
             Orientation="Horizontal">
@@ -40,5 +47,5 @@
                 Click="BtnAddAlarm_Click"
                 Content="Add" />
         </StackPanel>
-    </StackPanel>
+    </Grid>
 </util:MyPage>

--- a/USca/DbManager/Alarms/AlarmsDashboard.xaml
+++ b/USca/DbManager/Alarms/AlarmsDashboard.xaml
@@ -1,24 +1,22 @@
-﻿<util:MyPage
+﻿<UserControl
     x:Class="USca_DbManager.Alarms.AlarmsDashboard"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:USca_DbManager.Alarms"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:util="clr-namespace:USca_DbManager.Util"
-    Title="Alarms dashboard"
-    Height="400"
-    d:DesignHeight="450"
-    d:DesignWidth="800"
+    d:Height="480"
+    d:Width="640"
     DataContext="{Binding RelativeSource={RelativeSource Self}}"
     mc:Ignorable="d">
-    <Grid>
+    <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition />
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
         <DataGrid
             Grid.Row="0"
+            Margin="10"
             AutoGenerateColumns="False"
             IsReadOnly="True"
             ItemsSource="{Binding Alarms}"
@@ -48,4 +46,4 @@
                 Content="Add" />
         </StackPanel>
     </Grid>
-</util:MyPage>
+</UserControl>

--- a/USca/DbManager/Alarms/AlarmsDashboard.xaml.cs
+++ b/USca/DbManager/Alarms/AlarmsDashboard.xaml.cs
@@ -1,15 +1,15 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
-using USca_DbManager.Util;
 
 namespace USca_DbManager.Alarms
 {
     /// <summary>
     /// Interaction logic for AlarmsDashboard.xaml
     /// </summary>
-    public partial class AlarmsDashboard : MyPage
+    public partial class AlarmsDashboard : UserControl
     {
         public ObservableCollection<AlarmDTO> Alarms { get; set; } = new();
         public AlarmDTO? SelectedAlarm { get; set; }
@@ -34,8 +34,8 @@ namespace USca_DbManager.Alarms
         {
             var dialog = new AddAlarm
             {
-                Owner = Owner
-            };
+                Owner = (MainWindow)Window.GetWindow(this)
+        };
             if (dialog.ShowDialog() == true)
             {
                 await AlarmService.AddAlarm(dialog.Alarm);
@@ -67,8 +67,8 @@ namespace USca_DbManager.Alarms
 
             var dialog = new AddAlarm(SelectedAlarm)
             {
-                Owner = Owner
-            };
+                Owner = (MainWindow)Window.GetWindow(this)
+        };
             if (dialog.ShowDialog() == true)
             {
                 await AlarmService.UpdateAlarm(dialog.Alarm);

--- a/USca/DbManager/Alarms/AlarmsDashboard.xaml.cs
+++ b/USca/DbManager/Alarms/AlarmsDashboard.xaml.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Input;
+using USca_DbManager.Util;
+
+namespace USca_DbManager.Alarms
+{
+    /// <summary>
+    /// Interaction logic for AlarmsDashboard.xaml
+    /// </summary>
+    public partial class AlarmsDashboard : MyPage
+    {
+        public ObservableCollection<AlarmDTO> Alarms { get; set; } = new();
+        public AlarmDTO? SelectedAlarm { get; set; }
+
+        public AlarmsDashboard()
+        {
+            InitializeComponent();
+            LoadAlarms();
+        }
+
+        private async void LoadAlarms()
+        {
+            var alarms = await AlarmService.GetAllAlarms();
+            Alarms.Clear();
+            foreach (var alarm in alarms)
+            {
+                Alarms.Add(alarm);
+            }
+        }
+
+        private void BtnAddAlarm_Click(object sender, RoutedEventArgs e)
+        {
+
+        }
+
+        private async void BtnDeleteAlarm_Click(object sender, RoutedEventArgs e)
+        {
+            if (SelectedAlarm == null)
+            {
+                return;
+            }
+
+            var dialog = MessageBox.Show($"Are you sure you want to delete the alarm?", "Delete", MessageBoxButton.YesNo);
+            if (dialog == MessageBoxResult.Yes)
+            {
+                await AlarmService.DeleteAlarm(SelectedAlarm.Id);
+                LoadAlarms();
+            }
+        }
+
+        private void TbAlarms_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+        }
+    }
+}

--- a/USca/DbManager/Alarms/AlarmsDashboard.xaml.cs
+++ b/USca/DbManager/Alarms/AlarmsDashboard.xaml.cs
@@ -30,9 +30,17 @@ namespace USca_DbManager.Alarms
             }
         }
 
-        private void BtnAddAlarm_Click(object sender, RoutedEventArgs e)
+        private async void BtnAddAlarm_Click(object sender, RoutedEventArgs e)
         {
-
+            var dialog = new AddAlarm
+            {
+                Owner = Owner
+            };
+            if (dialog.ShowDialog() == true)
+            {
+                await AlarmService.AddAlarm(dialog.Alarm);
+                LoadAlarms();
+            }
         }
 
         private async void BtnDeleteAlarm_Click(object sender, RoutedEventArgs e)
@@ -50,8 +58,22 @@ namespace USca_DbManager.Alarms
             }
         }
 
-        private void TbAlarms_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        private async void TbAlarms_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
+            if (SelectedAlarm == null)
+            {
+                return;
+            }
+
+            var dialog = new AddAlarm(SelectedAlarm)
+            {
+                Owner = Owner
+            };
+            if (dialog.ShowDialog() == true)
+            {
+                await AlarmService.UpdateAlarm(dialog.Alarm);
+                LoadAlarms();
+            }
         }
     }
 }

--- a/USca/DbManager/MainWindow.xaml.cs
+++ b/USca/DbManager/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+using USca_DbManager.Alarms;
 using USca_DbManager.User;
 using USca_DbManager.Util;
 
@@ -9,7 +10,7 @@ namespace USca_DbManager
 		public MainWindow()
 		{
 			InitializeComponent();
-			Navigate(new Login());
+			Navigate(new AlarmsDashboard());
 		}
 
 		public void Navigate(MyPage page)

--- a/USca/DbManager/MainWindow.xaml.cs
+++ b/USca/DbManager/MainWindow.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System.Windows;
-using USca_DbManager.Alarms;
 using USca_DbManager.User;
 using USca_DbManager.Util;
 
@@ -10,7 +9,7 @@ namespace USca_DbManager
 		public MainWindow()
 		{
 			InitializeComponent();
-			Navigate(new AlarmsDashboard());
+			Navigate(new Login());
 		}
 
 		public void Navigate(MyPage page)

--- a/USca/DbManager/Tags/TagDTO.cs
+++ b/USca/DbManager/Tags/TagDTO.cs
@@ -15,5 +15,10 @@ namespace USca_DbManager.Tags
         public string Unit { get; set; } = "";
         public int ScanTime { get; set; } = 1000;
         public bool IsScanning { get; set; } = true;
+
+        public static string SimpleString(TagDTO tag)
+        {
+            return $"({tag.Id}) {tag.Name}";
+        }
     }
 }

--- a/USca/DbManager/Tags/TagService.cs
+++ b/USca/DbManager/Tags/TagService.cs
@@ -27,7 +27,24 @@ namespace USca_DbManager.Tags
 			}
 		}
 
-		public static async Task<RestResponse> AddTag(TagDTO tag)
+        public static async Task<List<TagDTO>> GetAnalogTags()
+        {
+            using var cli = new RestClient(new RestClientOptions(URL));
+            var req = new RestRequest("tag/analog", Method.Get);
+            RestResponse response = await cli.ExecuteAsync(req);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.OK)
+            {
+                var li = JsonSerializer.Deserialize<List<TagDTO>>(response.Content);
+                return li;
+            }
+            else
+            {
+                throw new Exception(response.StatusCode.ToString());
+            }
+        }
+
+        public static async Task<RestResponse> AddTag(TagDTO tag)
 		{
             using var cli = new RestClient(new RestClientOptions(URL));
             var req = new RestRequest("tag", Method.Post);

--- a/USca/DbManager/Tags/TagsDashboard.xaml
+++ b/USca/DbManager/Tags/TagsDashboard.xaml
@@ -1,5 +1,4 @@
-﻿<util:MyPage  xmlns:util="clr-namespace:USca_DbManager.Util"
-			  x:Class="USca_DbManager.Tags.TagsDashboard"
+﻿<UserControl  x:Class="USca_DbManager.Tags.TagsDashboard"
 			  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -8,8 +7,6 @@
 			  mc:Ignorable="d"
 			  d:Width="640"
 			  d:Height="480"
-			  Title="TagsDashboard"
-			  Background="White"
 			  DataContext="{Binding RelativeSource={RelativeSource Self}}">
 	<Grid Margin="10">
 		<Grid.RowDefinitions>
@@ -115,17 +112,22 @@
                 </DataGridTemplateColumn>
 			</DataGrid.Columns>
 		</DataGrid>
-
-		<StackPanel Orientation="Horizontal"
-					Grid.Row="1">
-			<Button Content="Delete"
-					Width="100"
-					x:Name="BtnDelTag"
-					Click="BtnDelTag_Click" />
-			<Button Content="Add"
-					Width="100"
-					x:Name="BtnAddTag"
-					Click="BtnAddTag_Click" />
+		<StackPanel
+			Grid.Row="1"
+			Margin="5"
+			HorizontalAlignment="Right"
+			Orientation="Horizontal">
+			<Button
+				Width="100"
+				Margin="0,0,10,0"
+				x:Name="BtnDelTag"
+				Click="BtnDelTag_Click"
+				Content="Delete" />
+			<Button
+				Width="100"
+				x:Name="BtnAddTag"
+				Click="BtnAddTag_Click"
+				Content="Add" />
 		</StackPanel>
 	</Grid>
-</util:MyPage>
+</UserControl>

--- a/USca/DbManager/Tags/TagsDashboard.xaml.cs
+++ b/USca/DbManager/Tags/TagsDashboard.xaml.cs
@@ -1,12 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
-using USca_DbManager.Util;
 
 namespace USca_DbManager.Tags
 {
-	public partial class TagsDashboard : MyPage
+	public partial class TagsDashboard : UserControl
     {
         public ObservableCollection<TagDTO> Tags { get; set; } = new();
         public TagDTO? SelectedTag { get; set; } = null;
@@ -20,7 +20,7 @@ namespace USca_DbManager.Tags
         private async void BtnAddTag_Click(object sender, RoutedEventArgs e)
         {
             var dialog = new AddTag();
-            dialog.Owner = Owner;
+            dialog.Owner = (MainWindow)Window.GetWindow(this);
             if (dialog.ShowDialog() == true)
             {
                 await TagService.AddTag(dialog.TagData);
@@ -46,7 +46,7 @@ namespace USca_DbManager.Tags
             }
 
             var dialog = new AddTag(SelectedTag);
-            dialog.Owner = Owner;
+            dialog.Owner = (MainWindow)Window.GetWindow(this);
             if (dialog.ShowDialog() == true)
             {
                 await TagService.UpdateTag(dialog.TagData);

--- a/USca/DbManager/User/Views/Dashboard.xaml
+++ b/USca/DbManager/User/Views/Dashboard.xaml
@@ -1,0 +1,26 @@
+﻿<util:MyPage
+    x:Class="USca_DbManager.User.Views.Dashboard"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:alarm="clr-namespace:USca_DbManager.Alarms"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:USca_DbManager.User.Views"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:tag="clr-namespace:USca_DbManager.Tags"
+    xmlns:util="clr-namespace:USca_DbManager.Util"
+    Title="Dashboard"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    mc:Ignorable="d">
+
+    <Grid>
+        <TabControl>
+            <TabItem Header="Tags">
+                <tag:TagsDashboard />
+            </TabItem>
+            <TabItem Header="Alarms">
+                <alarm:AlarmsDashboard />
+            </TabItem>
+        </TabControl>
+    </Grid>
+</util:MyPage>

--- a/USca/DbManager/User/Views/Dashboard.xaml.cs
+++ b/USca/DbManager/User/Views/Dashboard.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using USca_DbManager.Util;
+
+namespace USca_DbManager.User.Views
+{
+    /// <summary>
+    /// Interaction logic for Dashboard.xaml
+    /// </summary>
+    public partial class Dashboard : MyPage
+    {
+        public Dashboard()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/USca/DbManager/User/Views/Login.xaml
+++ b/USca/DbManager/User/Views/Login.xaml
@@ -9,6 +9,7 @@
 	mc:Ignorable="d" 
 	Background="LightSalmon"
 	d:Width="640" d:Height="480"
+	KeyDown="Login_KeyDown"
 	Title="Login">
 
 	<StackPanel Margin="100 0 100 0" VerticalAlignment="Center">

--- a/USca/DbManager/User/Views/Login.xaml.cs
+++ b/USca/DbManager/User/Views/Login.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Input;
 using USca_DbManager.Tags;
+using USca_DbManager.User.Views;
 using USca_DbManager.Util;
 
 namespace USca_DbManager.User
@@ -11,6 +12,9 @@ namespace USca_DbManager.User
 		public Login()
 		{
 			InitializeComponent();
+            tbUsername.Focus();
+            tbUsername.Text = "user1";
+            tbPassword.Password = "1234";
 		}
 
 		private void btnLogin_Click(object sender, RoutedEventArgs e)
@@ -30,7 +34,7 @@ namespace USca_DbManager.User
 				var res = await UserService.Login(username, password);
 				MessageBox.Show($"Logged in as {res.username}", "Alert.", MessageBoxButton.OK, MessageBoxImage.Exclamation);
 
-				Owner.Navigate(new TagsDashboard());
+				Owner.Navigate(new Dashboard());
 				var res2 = await TagService.GetAllTags();
 				Console.WriteLine(res2);
 			}
@@ -46,5 +50,13 @@ namespace USca_DbManager.User
 				btnLogin.IsEnabled = true;
 			}
 		}
-	}
+
+        private void Login_KeyDown(object sender, KeyEventArgs e)
+        {
+			if (e.Key == Key.Enter)
+			{
+				DoLogin(tbUsername.Text, tbPassword.Password);
+			}
+        }
+    }
 }

--- a/USca/DbManager/Util/Converters.cs
+++ b/USca/DbManager/Util/Converters.cs
@@ -2,6 +2,7 @@
 using System.Windows.Data;
 using System.Windows;
 using System.Globalization;
+using USca_DbManager.Tags;
 
 namespace USca_DbManager.Util
 {
@@ -39,6 +40,23 @@ namespace USca_DbManager.Util
             {
                 return !val;
             }
+            return value;
+        }
+    }
+
+    public class TagDTOToCustomStringConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is TagDTO tag)
+            {
+                return TagDTO.SimpleString(tag);
+            }
+            return value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
             return value;
         }
     }

--- a/USca/USca-Server/Alarms/Alarm.cs
+++ b/USca/USca-Server/Alarms/Alarm.cs
@@ -12,9 +12,9 @@ namespace USca_Server.Alarms
 
     public enum AlarmPriority
     {
-        LOW = 1,
-        MEDIUM = 2,
-        HIGH = 3,
+        LOW,
+        MEDIUM,
+        HIGH,
     }
 
     public class Alarm

--- a/USca/USca-Server/Alarms/Alarm.cs
+++ b/USca/USca-Server/Alarms/Alarm.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+using USca_Server.Tags;
+
+namespace USca_Server.Alarms
+{
+    public enum AlarmThresholdType
+    {
+        BELOW, // Trigger alarm when value drops below threshold
+        ABOVE, // Trigger alarm when value rises above threshold
+    }
+
+    public enum AlarmPriority
+    {
+        LOW = 1,
+        MEDIUM = 2,
+        HIGH = 3,
+    }
+
+    public class Alarm
+    {
+        [Key]
+        public int Id { get; set; }
+        [Required]
+        public AlarmThresholdType ThresholdType { get; set; }
+        [Required]
+        public AlarmPriority Priority { get; set; }
+        [Required]
+        public double Threshold { get; set; }
+        [Required]
+        public int TagId { get; set; }
+        public virtual Tag Tag { get; set; } = new();
+
+        public override string ToString()
+        {
+            return $"Alarm[Id={Id}, ThresholdType={ThresholdType}, Priority={Priority}, Threshold={Threshold}, TagId={TagId}]";
+        }
+    }
+}

--- a/USca/USca-Server/Alarms/Alarm.cs
+++ b/USca/USca-Server/Alarms/Alarm.cs
@@ -17,6 +17,19 @@ namespace USca_Server.Alarms
         HIGH,
     }
 
+    public static class ExtensionMethods
+    {
+        public static string ToSign(this AlarmThresholdType type)
+        {
+            return type switch
+            {
+                AlarmThresholdType.ABOVE => ">",
+                AlarmThresholdType.BELOW => "<",
+                _ => throw new NotImplementedException()
+            };
+        }
+    }
+
     public class Alarm
     {
         [Key]
@@ -35,6 +48,16 @@ namespace USca_Server.Alarms
         public override string ToString()
         {
             return $"Alarm[Id={Id}, ThresholdType={ThresholdType}, Priority={Priority}, Threshold={Threshold}, TagId={TagId}]";
+        }
+
+        public bool ThresholdCrossed(double value)
+        {
+            return ThresholdType switch
+            {
+                AlarmThresholdType.BELOW => value < Threshold,
+                AlarmThresholdType.ABOVE => value > Threshold,
+                _ => throw new NotImplementedException()
+            };
         }
     }
 }

--- a/USca/USca-Server/Alarms/AlarmAddDTO.cs
+++ b/USca/USca-Server/Alarms/AlarmAddDTO.cs
@@ -1,0 +1,10 @@
+namespace USca_Server.Alarms
+{
+    public class AlarmAddDTO
+    {
+        public AlarmThresholdType ThresholdType { get; set; }
+        public AlarmPriority Priority { get; set; }
+        public double Threshold { get; set; }
+        public int TagId { get; set; }
+    }
+}

--- a/USca/USca-Server/Alarms/AlarmController.cs
+++ b/USca/USca-Server/Alarms/AlarmController.cs
@@ -39,5 +39,19 @@ namespace USca_Server.Alarms
             _alarmService.Update(alarmUpdateDTO);
             return StatusCode(204);
         }
+
+        [HttpGet("ws")]
+        public async Task OpenAlarmWebSocket()
+        {
+            if (HttpContext.WebSockets.IsWebSocketRequest)
+            {
+                using var ws = await HttpContext.WebSockets.AcceptWebSocketAsync();
+                await _alarmService.StartAlarmValuesListener(ws);
+            }
+            else
+            {
+                HttpContext.Response.StatusCode = 400;
+            }
+        }
     }
 }

--- a/USca/USca-Server/Alarms/AlarmController.cs
+++ b/USca/USca-Server/Alarms/AlarmController.cs
@@ -25,5 +25,19 @@ namespace USca_Server.Alarms
             _alarmService.Delete(alarmId);
             return StatusCode(204);
         }
+
+        [HttpPost]
+        public ActionResult AddAlarm(AlarmAddDTO alarmAddDTO)
+        {
+            _alarmService.Add(alarmAddDTO);
+            return StatusCode(204);
+        }
+
+        [HttpPut]
+        public ActionResult UpdateAlarm(AlarmUpdateDTO alarmUpdateDTO)
+        {
+            _alarmService.Update(alarmUpdateDTO);
+            return StatusCode(204);
+        }
     }
 }

--- a/USca/USca-Server/Alarms/AlarmController.cs
+++ b/USca/USca-Server/Alarms/AlarmController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace USca_Server.Alarms
+{
+    [Route("api/alarm")]
+    [ApiController]
+    public class AlarmController : ControllerBase
+    {
+        private IAlarmService _alarmService;
+
+        public AlarmController(IAlarmService alarmService)
+        {
+            _alarmService = alarmService;
+        }
+
+        [HttpGet]
+        public ActionResult<List<Alarm>> GetAllAlarms()
+        {
+            return StatusCode(200, _alarmService.GetAll());
+        }
+
+        [HttpDelete("{alarmId}")]
+        public ActionResult DeleteAlarm(int alarmId)
+        {
+            _alarmService.Delete(alarmId);
+            return StatusCode(204);
+        }
+    }
+}

--- a/USca/USca-Server/Alarms/AlarmLog.cs
+++ b/USca/USca-Server/Alarms/AlarmLog.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace USca_Server.Alarms
+{
+    public class AlarmLog
+    {
+        [Key]
+        public int Id { get; set; }
+        public int AlarmId { get; set; }
+        public AlarmThresholdType ThresholdType { get; set; }
+        public AlarmPriority Priority { get; set; }
+        public double Threshold { get; set; }
+        public int TagId { get; set; }
+        public string? TagName { get; set; }
+        public int Address { get; set; }
+        public DateTime TimeStamp { get; set; }
+        public double RecordedValue { get; set; }
+
+        public static string LogEntry(AlarmLog log)
+        {
+            return $"[{log.Priority} {log.TimeStamp}] Tag {log.TagId} ({log.TagName}) recorded alarm {log.AlarmId} at address {log.Address}: {log.RecordedValue:#.####} {log.ThresholdType.ToSign()} {log.Threshold:#.####}";
+        }
+    }
+}

--- a/USca/USca-Server/Alarms/AlarmService.cs
+++ b/USca/USca-Server/Alarms/AlarmService.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using USca_Server.Shared;
+
+namespace USca_Server.Alarms
+{
+    public class AlarmService : IAlarmService
+    {
+
+        public List<Alarm> GetAll()
+        {
+            using var db = new ServerDbContext();
+            return db.Alarms.Include(a => a.Tag).ToList();
+        }
+
+        public void Delete(int alarmId)
+        {
+            using var db = new ServerDbContext();
+            var alarm = db.Alarms.Find(alarmId);
+            if (alarm == null)
+            {
+                return;
+            }
+            db.Alarms.Remove(alarm);
+            db.SaveChanges();
+        }
+    }
+}

--- a/USca/USca-Server/Alarms/AlarmService.cs
+++ b/USca/USca-Server/Alarms/AlarmService.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
+using System.Net.WebSockets;
 using USca_Server.Shared;
 using USca_Server.Tags;
+using USca_Server.Util;
 
 namespace USca_Server.Alarms
 {
@@ -50,6 +52,16 @@ namespace USca_Server.Alarms
             }
             db.Alarms.Entry(alarm).CurrentValues.SetValues(alarmUpdateDTO);
             db.SaveChanges();
+        }
+
+        public async Task StartAlarmValuesListener(WebSocket ws)
+        {
+            List<SocketMessageType> supportedMessageTypes = new()
+            {
+                SocketMessageType.ALARM_TRIGGERED,
+            };
+            SocketWorker listener = new(ws, supportedMessageTypes);
+            await listener.Start();
         }
     }
 }

--- a/USca/USca-Server/Alarms/AlarmService.cs
+++ b/USca/USca-Server/Alarms/AlarmService.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using USca_Server.Shared;
+using USca_Server.Tags;
 
 namespace USca_Server.Alarms
 {
@@ -21,6 +22,33 @@ namespace USca_Server.Alarms
                 return;
             }
             db.Alarms.Remove(alarm);
+            db.SaveChanges();
+        }
+
+        public void Add(AlarmAddDTO alarmAddDTO)
+        {
+            using var db = new ServerDbContext();
+
+            Alarm alarm = new()
+            {
+                ThresholdType = alarmAddDTO.ThresholdType,
+                Priority = alarmAddDTO.Priority,
+                Threshold = alarmAddDTO.Threshold,
+                Tag = db.Tags.Find(alarmAddDTO.TagId) ?? new(), // FIXME: Dumb
+            };
+            db.Alarms.Add(alarm);
+            db.SaveChanges();
+        }
+
+        public void Update(AlarmUpdateDTO alarmUpdateDTO)
+        {
+            using var db = new ServerDbContext();
+            var alarm = db.Alarms.Find(alarmUpdateDTO.Id);
+            if (alarm == null)
+            {
+                return;
+            }
+            db.Alarms.Entry(alarm).CurrentValues.SetValues(alarmUpdateDTO);
             db.SaveChanges();
         }
     }

--- a/USca/USca-Server/Alarms/AlarmUpdateDTO.cs
+++ b/USca/USca-Server/Alarms/AlarmUpdateDTO.cs
@@ -1,0 +1,11 @@
+namespace USca_Server.Alarms
+{
+    public class AlarmUpdateDTO
+    {
+        public int Id { get; set; }
+        public AlarmThresholdType ThresholdType { get; set; }
+        public AlarmPriority Priority { get; set; }
+        public double Threshold { get; set; }
+        public int TagId { get; set; }
+    }
+}

--- a/USca/USca-Server/Alarms/IAlarmService.cs
+++ b/USca/USca-Server/Alarms/IAlarmService.cs
@@ -1,0 +1,8 @@
+namespace USca_Server.Alarms
+{
+    public interface IAlarmService
+    {
+        public List<Alarm> GetAll();
+        public void Delete(int alarmId);
+    }
+}

--- a/USca/USca-Server/Alarms/IAlarmService.cs
+++ b/USca/USca-Server/Alarms/IAlarmService.cs
@@ -1,3 +1,5 @@
+using System.Net.WebSockets;
+
 namespace USca_Server.Alarms
 {
     public interface IAlarmService
@@ -6,5 +8,6 @@ namespace USca_Server.Alarms
         public void Add(AlarmAddDTO alarmAddDTO);
         public void Update(AlarmUpdateDTO alarmUpdateDTO);
         public void Delete(int alarmId);
+        public Task StartAlarmValuesListener(WebSocket ws);
     }
 }

--- a/USca/USca-Server/Alarms/IAlarmService.cs
+++ b/USca/USca-Server/Alarms/IAlarmService.cs
@@ -3,6 +3,8 @@ namespace USca_Server.Alarms
     public interface IAlarmService
     {
         public List<Alarm> GetAll();
+        public void Add(AlarmAddDTO alarmAddDTO);
+        public void Update(AlarmUpdateDTO alarmUpdateDTO);
         public void Delete(int alarmId);
     }
 }

--- a/USca/USca-Server/Program.cs
+++ b/USca/USca-Server/Program.cs
@@ -1,3 +1,4 @@
+using USca_Server.Alarms;
 using USca_Server.Measures;
 using USca_Server.Shared;
 using USca_Server.Tags;
@@ -17,6 +18,7 @@ namespace USca_Server
 			builder.Services.AddScoped(typeof(IUserService), typeof(UserService));
 			builder.Services.AddScoped(typeof(IMeasureService), typeof(MeasureService));
             builder.Services.AddScoped(typeof(ITagService), typeof(TagService));
+            builder.Services.AddScoped(typeof(IAlarmService), typeof(AlarmService));
             builder.Services.AddDbContext<ServerDbContext>();
             builder.Services.AddControllers().AddJsonOptions(options =>options.JsonSerializerOptions.PropertyNamingPolicy = null);
 

--- a/USca/USca-Server/Shared/ServerDbContext.cs
+++ b/USca/USca-Server/Shared/ServerDbContext.cs
@@ -93,7 +93,7 @@ namespace USca_Server.Shared
             {
                 ThresholdType = AlarmThresholdType.BELOW,
                 Priority = AlarmPriority.MEDIUM,
-                Threshold = 0.5,
+                Threshold = 4.6,
                 Tag = tag1,
             };
             Alarms.Add(a2);

--- a/USca/USca-Server/Shared/ServerDbContext.cs
+++ b/USca/USca-Server/Shared/ServerDbContext.cs
@@ -12,6 +12,7 @@ namespace USca_Server.Shared
         public DbSet<Measure> Measures { get; set; }
 		public DbSet<Tag> Tags { get; set; }
         public DbSet<Alarm> Alarms { get; set; }
+        public DbSet<AlarmLog> AlarmLogs { get; set; }
 
 		private static bool _created = false;
         private static readonly object _lock = new();

--- a/USca/USca-Server/Shared/ServerDbContext.cs
+++ b/USca/USca-Server/Shared/ServerDbContext.cs
@@ -108,15 +108,6 @@ namespace USca_Server.Shared
             Alarms.Add(a3);
 
             SaveChanges();
-
-            Console.WriteLine($"Tag 1 alarms:");
-            tag1.Alarms.ForEach(a => Console.WriteLine($"   {a}"));
-
-            Console.WriteLine($"Tag 2 alarms:");
-            tag2.Alarms.ForEach(a => Console.WriteLine($"   {a}"));
-
-            Console.WriteLine($"Tag 3 alarms:");
-            tag3.Alarms.ForEach(a => Console.WriteLine($"   {a}"));
         }
 
 		protected override void OnConfiguring(DbContextOptionsBuilder options)

--- a/USca/USca-Server/Shared/ServerDbContext.cs
+++ b/USca/USca-Server/Shared/ServerDbContext.cs
@@ -106,6 +106,8 @@ namespace USca_Server.Shared
             };
             Alarms.Add(a3);
 
+            SaveChanges();
+
             Console.WriteLine($"Tag 1 alarms:");
             tag1.Alarms.ForEach(a => Console.WriteLine($"   {a}"));
 
@@ -114,8 +116,6 @@ namespace USca_Server.Shared
 
             Console.WriteLine($"Tag 3 alarms:");
             tag3.Alarms.ForEach(a => Console.WriteLine($"   {a}"));
-
-            SaveChanges();
         }
 
 		protected override void OnConfiguring(DbContextOptionsBuilder options)

--- a/USca/USca-Server/Shared/ServerDbContext.cs
+++ b/USca/USca-Server/Shared/ServerDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using USca_Server.Alarms;
 using USca_Server.Measures;
 using USca_Server.Tags;
 using USca_Server.Users;
@@ -10,6 +11,7 @@ namespace USca_Server.Shared
         public DbSet<User> Users { get; set; }
         public DbSet<Measure> Measures { get; set; }
 		public DbSet<Tag> Tags { get; set; }
+        public DbSet<Alarm> Alarms { get; set; }
 
 		private static bool _created = false;
         private static readonly object _lock = new();
@@ -33,7 +35,7 @@ namespace USca_Server.Shared
             Users.Add(new() { Name = "Bab", Surname = "Janes", Username = "user2", Password = "1234" });
             Users.Add(new() { Name = "Bib", Surname = "Jines", Username = "user3", Password = "1234" });
 
-            Tags.Add(new()
+            Tag tag1 = new()
             {
                 Address = 1,
                 Name = "Tank01",
@@ -41,8 +43,10 @@ namespace USca_Server.Shared
                 Unit = "litre",
                 Min = 0,
                 Max = 10,
-            });
-            Tags.Add(new() 
+            };
+            Tags.Add(tag1);
+
+            Tag tag2 = new() 
             {
                 Address = 2,
                 Name = "Tank01_ValveIn",
@@ -50,8 +54,10 @@ namespace USca_Server.Shared
                 Unit = "litre",
                 Min = 0,
                 Max = 1,
-            });
-            Tags.Add(new()
+            };
+            Tags.Add(tag2);
+
+            Tag tag3 = new()
             { 
                 Address = 3,
                 Name = "Tank01_ValveIn_Reserve",
@@ -59,8 +65,10 @@ namespace USca_Server.Shared
                 Unit = "litre",
                 Min = 0,
                 Max = 1,
-            });
-            Tags.Add(new() 
+            };
+            Tags.Add(tag3);
+
+            Tag tag4 = new() 
             { 
                 Address = 4,
                 Name = "Tank01_ValveOut",
@@ -68,7 +76,44 @@ namespace USca_Server.Shared
                 Unit = "litre",
                 Min = 0,
                 Max = 1,
-            });
+            };
+            Tags.Add(tag4);
+
+            Alarm a1 = new()
+            {
+                ThresholdType = AlarmThresholdType.ABOVE,
+                Priority = AlarmPriority.HIGH,
+                Threshold = 9,
+                Tag = tag1,
+            };
+            Alarms.Add(a1);
+
+            Alarm a2 = new()
+            {
+                ThresholdType = AlarmThresholdType.BELOW,
+                Priority = AlarmPriority.MEDIUM,
+                Threshold = 0.5,
+                Tag = tag1,
+            };
+            Alarms.Add(a2);
+
+            Alarm a3 = new()
+            {
+                ThresholdType = AlarmThresholdType.ABOVE,
+                Priority = AlarmPriority.LOW,
+                Threshold = 0.0005,
+                Tag = tag2,
+            };
+            Alarms.Add(a3);
+
+            Console.WriteLine($"Tag 1 alarms:");
+            tag1.Alarms.ForEach(a => Console.WriteLine($"   {a}"));
+
+            Console.WriteLine($"Tag 2 alarms:");
+            tag2.Alarms.ForEach(a => Console.WriteLine($"   {a}"));
+
+            Console.WriteLine($"Tag 3 alarms:");
+            tag3.Alarms.ForEach(a => Console.WriteLine($"   {a}"));
 
             SaveChanges();
         }

--- a/USca/USca-Server/Shared/SocketWorker.cs
+++ b/USca/USca-Server/Shared/SocketWorker.cs
@@ -1,0 +1,77 @@
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using USca_Server.Tags;
+using USca_Server.Util;
+
+namespace USca_Server.Shared
+{
+
+    public class SocketWorker
+    {
+        public WebSocket Ws { get; set; }
+        public List<SocketMessageType> SupportedTypes { get; set; }
+        public SocketWorker(WebSocket ws, List<SocketMessageType> supportedTypes)
+        {
+            Ws = ws;
+            SupportedTypes = supportedTypes;
+        }
+
+        public async void HandleTagWorkerEvent(object? sender, SocketMessageDTO e)
+        {
+            if (!SupportedTypes.Contains(e.Type))
+            {
+                return;
+            }
+            var json = JsonSerializer.Serialize(e);
+            await Ws.SendAsync(
+                new(Encoding.UTF8.GetBytes(json)),
+                WebSocketMessageType.Text,
+                true,
+                CancellationToken.None
+            );
+        }
+
+        public async Task Start()
+        {
+            TagWorker.RaiseWorkerEvent += HandleTagWorkerEvent;
+            Console.WriteLine("Started socket loop");
+            await WebSocketLoop();
+            TagWorker.RaiseWorkerEvent -= HandleTagWorkerEvent;
+            Console.WriteLine("Stopped socket loop (connection closed)");
+        }
+
+        /// <summary>
+        /// This method runs the main WebSocket code for this Worker.
+        /// <br/>
+        /// It waits for a message from the other side, and if it receives a <c>WebSocketMessageType.Close</c>, it closes the WebSocket.
+        /// <br/>
+        /// This method returning implies that the WebSocket connection is closed.
+        /// </summary>
+        private async Task WebSocketLoop()
+        {
+            while (Ws.State == WebSocketState.Open)
+            {
+                var buffer = new byte[1024 * 4];
+
+                try
+                {
+                    var result = await Ws.ReceiveAsync(buffer, CancellationToken.None);
+
+                    if (result.MessageType == WebSocketMessageType.Close)
+                    {
+                        await Ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, CancellationToken.None);
+                    }
+                    else
+                    {
+                        Console.WriteLine(Encoding.ASCII.GetString(buffer, 0, result.Count));
+                    }
+                }
+                catch (WebSocketException)
+                {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/USca/USca-Server/Tags/ITagService.cs
+++ b/USca/USca-Server/Tags/ITagService.cs
@@ -7,6 +7,7 @@ namespace USca_Server.Tags
         public void Add(TagAddDTO dto);
         public Tag? Get(int id);
         public List<Tag> GetAll();
+        public List<Tag> GetAnalog();
         public void Update(TagDTO dto);
         public void Delete(int id);
 

--- a/USca/USca-Server/Tags/ITagService.cs
+++ b/USca/USca-Server/Tags/ITagService.cs
@@ -11,6 +11,6 @@ namespace USca_Server.Tags
         public void Update(TagDTO dto);
         public void Delete(int id);
 
-        public Task SendTagValues(WebSocket ws);
+        public Task StartTagValuesListener(WebSocket ws);
     }
 }

--- a/USca/USca-Server/Tags/Tag.cs
+++ b/USca/USca-Server/Tags/Tag.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 using USca_Server.Alarms;
 
 namespace USca_Server.Tags
@@ -29,6 +30,7 @@ namespace USca_Server.Tags
         public string Unit { get; set; } = "";
         public int ScanTime { get; set; } = 1000;
         public bool IsScanning { get; set; } = true;
+        [JsonIgnore]
         public virtual List<Alarm> Alarms { get; set; } = new();
 
         public Tag()

--- a/USca/USca-Server/Tags/Tag.cs
+++ b/USca/USca-Server/Tags/Tag.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using USca_Server.Alarms;
 
 namespace USca_Server.Tags
 {
@@ -28,6 +29,7 @@ namespace USca_Server.Tags
         public string Unit { get; set; } = "";
         public int ScanTime { get; set; } = 1000;
         public bool IsScanning { get; set; } = true;
+        public virtual List<Alarm> Alarms { get; set; } = new();
 
         public Tag()
         {

--- a/USca/USca-Server/Tags/TagController.cs
+++ b/USca/USca-Server/Tags/TagController.cs
@@ -20,6 +20,13 @@ namespace USca_Server.Tags
             return StatusCode(200, res);
         }
 
+        [HttpGet("analog")]
+        public ActionResult<List<Tag>> GetAnalogTags()
+        {
+            var res = _tagService.GetAnalog();
+            return StatusCode(200, res);
+        }
+
         [HttpPost]
         public ActionResult<object> AddTag(TagAddDTO dto)
         {

--- a/USca/USca-Server/Tags/TagController.cs
+++ b/USca/USca-Server/Tags/TagController.cs
@@ -18,9 +18,16 @@ namespace USca_Server.Tags
 		{
 			var res = _tagService.GetAll();
 			return StatusCode(200, res);
-		}
+        }
 
-		[HttpPost]
+        [HttpGet("analog")]
+        public ActionResult<List<Tag>> GetAnalogTags()
+        {
+            var res = _tagService.GetAnalog();
+            return StatusCode(200, res);
+        }
+
+        [HttpPost]
         public ActionResult<object> AddTag(TagAddDTO dto)
         {
 			_tagService.Add(dto);

--- a/USca/USca-Server/Tags/TagController.cs
+++ b/USca/USca-Server/Tags/TagController.cs
@@ -56,7 +56,7 @@ namespace USca_Server.Tags
             {
                 using (var ws = await HttpContext.WebSockets.AcceptWebSocketAsync())
                 {
-                    await _tagService.SendTagValues(ws);
+                    await _tagService.StartTagValuesListener(ws);
                 }
             }
             else

--- a/USca/USca-Server/Tags/TagService.cs
+++ b/USca/USca-Server/Tags/TagService.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.WebSockets;
+﻿using Microsoft.EntityFrameworkCore;
+using System.Net.WebSockets;
 using USca_Server.Shared;
 
 namespace USca_Server.Tags
@@ -42,7 +43,7 @@ namespace USca_Server.Tags
         {
             using (var db = new ServerDbContext())
             {
-                return db.Tags.ToList();
+                return db.Tags.Include(t => t.Alarms).ToList();
             }
         }
 

--- a/USca/USca-Server/Tags/TagService.cs
+++ b/USca/USca-Server/Tags/TagService.cs
@@ -1,6 +1,9 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
 using USca_Server.Shared;
+using USca_Server.Util;
 
 namespace USca_Server.Tags
 {
@@ -68,14 +71,15 @@ namespace USca_Server.Tags
             }
         }
 
-        public async Task SendTagValues(WebSocket ws)
+        public async Task StartTagValuesListener(WebSocket ws)
         {
-            Console.WriteLine("Connected");
-
-            TagWorker tagTrendingWorker = new(ws, this);
-            await tagTrendingWorker.Start();
-
-            Console.WriteLine("Disconnected");
+            List<SocketMessageType> supportedMessageTypes = new()
+            {
+                SocketMessageType.UPDATE_TAG_READING,
+                SocketMessageType.DELETE_TAG_READING,
+            };
+            SocketWorker listener = new(ws, supportedMessageTypes);
+            await listener.Start();
         }
     }
 }

--- a/USca/USca-Server/Tags/TagService.cs
+++ b/USca/USca-Server/Tags/TagService.cs
@@ -47,6 +47,14 @@ namespace USca_Server.Tags
             }
         }
 
+        public List<Tag> GetAnalog()
+        {
+            using (var db = new ServerDbContext())
+            {
+                return db.Tags.Where(t => t.Type == TagType.Analog).Include(t => t.Alarms).ToList();
+            }
+        }
+
         public void Update(TagDTO dto)
         {
             using (var db = new ServerDbContext())

--- a/USca/USca-Server/Tags/TagService.cs
+++ b/USca/USca-Server/Tags/TagService.cs
@@ -72,7 +72,7 @@ namespace USca_Server.Tags
         {
             Console.WriteLine("Connected");
 
-            TagTrendingWorker tagTrendingWorker = new(ws, this);
+            TagWorker tagTrendingWorker = new(ws, this);
             await tagTrendingWorker.Start();
 
             Console.WriteLine("Disconnected");

--- a/USca/USca-Server/Tags/TagWorker.cs
+++ b/USca/USca-Server/Tags/TagWorker.cs
@@ -11,7 +11,7 @@ namespace USca_Server.Tags
     /// <summary>
     /// TagTrendingWorker encapsulates all logic for sending current tag values to the Trending app.
     /// </summary>
-    public class TagTrendingWorker
+    public class TagWorker
     {
         public WebSocket Ws { get; set; }
         private Dictionary<int, TagThreadWrapper> _threads = new();
@@ -20,7 +20,7 @@ namespace USca_Server.Tags
         private static readonly object _lock = new();
         private const string alarmLogPath = "./alarmLog.txt";
 
-        public TagTrendingWorker(WebSocket ws, ITagService tagService)
+        public TagWorker(WebSocket ws, ITagService tagService)
         {
             Ws = ws;
             _tagService = tagService;

--- a/USca/USca-Server/Tags/TagWorker.cs
+++ b/USca/USca-Server/Tags/TagWorker.cs
@@ -162,7 +162,7 @@ namespace USca_Server.Tags
                             TagId = Tag.Id,
                             TagName = Tag.Name,
                             Address = Tag.Address,
-                            TimeStamp = DateTime.Now,
+                            TimeStamp = measure.Timestamp,
                             RecordedValue = measure.Value,
                         };
                         db.AlarmLogs.Add(log);

--- a/USca/USca-Server/Util/SocketMessageDTO.cs
+++ b/USca/USca-Server/Util/SocketMessageDTO.cs
@@ -1,5 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace USca_Server.Util
 {
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum SocketMessageType
     {
         DELETE_TAG_READING,

--- a/USca/USca-Server/Util/SocketMessageDTO.cs
+++ b/USca/USca-Server/Util/SocketMessageDTO.cs
@@ -4,6 +4,7 @@ namespace USca_Server.Util
     {
         DELETE_TAG_READING,
         UPDATE_TAG_READING,
+        ALARM_TRIGGERED,
     }
 
     public class SocketMessageDTO

--- a/USca/USca.sln
+++ b/USca/USca.sln
@@ -9,7 +9,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "USca_DbManager", "DbManager
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "USca_RTU", "USca_RTU\USca_RTU.csproj", "{C232538A-E495-4954-A563-FB88C636670F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "USca_Trending", "USca_Trending\USca_Trending.csproj", "{6C9A6551-C11B-4CB8-990E-09B69054E98D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "USca_Trending", "USca_Trending\USca_Trending.csproj", "{6C9A6551-C11B-4CB8-990E-09B69054E98D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "USca_AlarmDisplay", "USca_AlarmDisplay\USca_AlarmDisplay.csproj", "{18F7A5B2-8740-4552-A533-96983D5E2ADD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +35,10 @@ Global
 		{6C9A6551-C11B-4CB8-990E-09B69054E98D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6C9A6551-C11B-4CB8-990E-09B69054E98D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6C9A6551-C11B-4CB8-990E-09B69054E98D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18F7A5B2-8740-4552-A533-96983D5E2ADD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18F7A5B2-8740-4552-A533-96983D5E2ADD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{18F7A5B2-8740-4552-A533-96983D5E2ADD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18F7A5B2-8740-4552-A533-96983D5E2ADD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/USca/USca_AlarmDisplay/Alarm/AlarmLogDTO.cs
+++ b/USca/USca_AlarmDisplay/Alarm/AlarmLogDTO.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace USca_AlarmDisplay.Alarm
+{
+    public enum AlarmThresholdType
+    {
+        BELOW, // Trigger alarm when value drops below threshold
+        ABOVE, // Trigger alarm when value rises above threshold
+    }
+
+    public enum AlarmPriority
+    {
+        LOW,
+        MEDIUM,
+        HIGH,
+    }
+
+    public static class ExtensionMethods
+    {
+        public static string ToSign(this AlarmThresholdType type)
+        {
+            return type switch
+            {
+                AlarmThresholdType.ABOVE => ">",
+                AlarmThresholdType.BELOW => "<",
+                _ => throw new NotImplementedException()
+            };
+        }
+    }
+
+    public partial class AlarmLogDTO : INotifyPropertyChanged
+    {
+        public int Id { get; set; }
+        public int AlarmId { get; set; }
+        public AlarmThresholdType ThresholdType { get; set; }
+        public AlarmPriority Priority { get; set; }
+        public double Threshold { get; set; }
+        public int TagId { get; set; }
+        public string? TagName { get; set; }
+        public int Address { get; set; }
+        public DateTime TimeStamp { get; set; }
+        public double RecordedValue { get; set; }
+
+        public static string LogEntry(AlarmLogDTO log)
+        {
+            return $"[{log.Priority} {log.TimeStamp}] Tag {log.TagId} ({log.TagName}) recorded alarm {log.AlarmId} at address {log.Address}: {log.RecordedValue:#.####} {log.ThresholdType.ToSign()} {log.Threshold:#.####}";
+        }
+    }
+}

--- a/USca/USca_AlarmDisplay/AlarmAlerts.xaml
+++ b/USca/USca_AlarmDisplay/AlarmAlerts.xaml
@@ -1,0 +1,35 @@
+﻿<Window
+    x:Class="USca_AlarmDisplay.AlarmAlerts"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:USca_AlarmDisplay"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Title="Alam alerts"
+    Width="800"
+    Height="450"
+    DataContext="{Binding RelativeSource={RelativeSource Self}}"
+    mc:Ignorable="d">
+    <Window.Resources>
+        <local:AlarmLogDTOToCustomStringConverter x:Key="logConverter" />
+    </Window.Resources>
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition />
+            <RowDefinition Height="auto" />
+        </Grid.RowDefinitions>
+        <ListBox Grid.Row="0" ItemsSource="{Binding AlarmLogs}">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding {}, Converter={StaticResource logConverter}}" />
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+        <Button
+            Grid.Row="1"
+            Width="100"
+            HorizontalAlignment="Right"
+            Click="BtnClear_Click"
+            Content="Clear" />
+    </Grid>
+</Window>

--- a/USca/USca_AlarmDisplay/AlarmAlerts.xaml.cs
+++ b/USca/USca_AlarmDisplay/AlarmAlerts.xaml.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Net.WebSockets;
+using System.Text.Json;
+using System.Text;
+using System.Threading;
+using System.Windows;
+using System.Windows.Data;
+using USca_AlarmDisplay.Alarm;
+using USca_AlarmDisplay.Util;
+
+namespace USca_AlarmDisplay
+{
+    public partial class AlarmAlerts : Window
+    {
+        public ObservableCollection<AlarmLogDTO> AlarmLogs { get; set; } = new();
+
+        public AlarmAlerts()
+        {
+            InitializeComponent();
+            OpenWebSocket();
+        }
+
+
+        private async void OpenWebSocket()
+        {
+            using var ws = new ClientWebSocket();
+            await ws.ConnectAsync(new Uri("ws://localhost:5274/api/alarm/ws"), CancellationToken.None);
+            var buffer = new byte[1024 * 4];
+
+            while (ws.State == WebSocketState.Open)
+            {
+                var result = await ws.ReceiveAsync(buffer, CancellationToken.None);
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, CancellationToken.None);
+                }
+                else
+                {
+                    // Get data...
+                    var dtoJson = Encoding.ASCII.GetString(buffer, 0, result.Count);
+                    SocketMessageDTO? socketMessage;
+                    try
+                    {
+                        socketMessage = JsonSerializer.Deserialize<SocketMessageDTO>(dtoJson);
+                    } catch (JsonException)
+                    {
+                        // Probably failed to deserialize SocketMessageType, which is fine
+                        continue;
+                    }
+                    if (socketMessage == null || socketMessage?.Type == null || socketMessage?.Message == null)
+                    {
+                        Console.WriteLine($"Strange socket message: {dtoJson}");
+                        continue;
+                    }
+                    switch (socketMessage.Type)
+                    {
+                        case SocketMessageType.ALARM_TRIGGERED:
+                            LoadAlarmLog(JsonSerializer.Deserialize<AlarmLogDTO>(socketMessage.Message));
+                            break;
+                        default:
+                            Console.WriteLine($"Unsupported message type: {socketMessage.Type}");
+                            break;
+                    }
+                }
+            }
+        }
+
+        private void LoadAlarmLog(AlarmLogDTO? log)
+        {
+            if (log == null)
+            {
+                return;
+            }
+            switch (log.Priority)
+            {
+                case AlarmPriority.LOW:
+                    AlarmLogs.Add(log);
+                    break;
+                case AlarmPriority.MEDIUM:
+                    AlarmLogs.Add(log);
+                    AlarmLogs.Add(log);
+                    break;
+                case AlarmPriority.HIGH:
+                    AlarmLogs.Add(log);
+                    AlarmLogs.Add(log);
+                    AlarmLogs.Add(log);
+                    break;
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        private void BtnClear_Click(object sender, RoutedEventArgs e)
+        {
+            AlarmLogs.Clear();
+        }
+    }
+
+    public class AlarmLogDTOToCustomStringConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is AlarmLogDTO log)
+            {
+                return AlarmLogDTO.LogEntry(log);
+            }
+            return value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value;
+        }
+    }
+}

--- a/USca/USca_AlarmDisplay/App.xaml
+++ b/USca/USca_AlarmDisplay/App.xaml
@@ -1,0 +1,8 @@
+﻿<Application
+    x:Class="USca_AlarmDisplay.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:USca_AlarmDisplay"
+    StartupUri="AlarmAlerts.xaml">
+    <Application.Resources />
+</Application>

--- a/USca/USca_AlarmDisplay/App.xaml.cs
+++ b/USca/USca_AlarmDisplay/App.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace USca_AlarmDisplay
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : Application
+    {
+    }
+}

--- a/USca/USca_AlarmDisplay/AssemblyInfo.cs
+++ b/USca/USca_AlarmDisplay/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+                                     //(used if a resource is not found in the page,
+                                     // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+                                              //(used if a resource is not found in the page,
+                                              // app, or any theme specific resource dictionaries)
+)]

--- a/USca/USca_AlarmDisplay/FodyWeavers.xml
+++ b/USca/USca_AlarmDisplay/FodyWeavers.xml
@@ -1,0 +1,3 @@
+﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <PropertyChanged />
+</Weavers>

--- a/USca/USca_AlarmDisplay/USca_AlarmDisplay.csproj
+++ b/USca/USca_AlarmDisplay/USca_AlarmDisplay.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net7.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
@@ -13,7 +13,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="PropertyChanged.Fody" Version="4.1.0" />
-    <PackageReference Include="RestSharp" Version="110.2.0" />
   </ItemGroup>
 
 </Project>

--- a/USca/USca_AlarmDisplay/Util/SocketMessageDTO.cs
+++ b/USca/USca_AlarmDisplay/Util/SocketMessageDTO.cs
@@ -1,18 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
+﻿using System.Text.Json.Serialization;
 
-namespace USca_Trending.Util
+namespace USca_AlarmDisplay.Util
 {
-
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum SocketMessageType
     {
-        DELETE_TAG_READING,
-        UPDATE_TAG_READING,
+        ALARM_TRIGGERED,
     }
 
     public class SocketMessageDTO

--- a/USca/USca_RTU/USca_RTU.csproj
+++ b/USca/USca_RTU/USca_RTU.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <TargetFramework>net7.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>

--- a/USca/USca_Trending/Tags/TagValues.xaml.cs
+++ b/USca/USca_Trending/Tags/TagValues.xaml.cs
@@ -40,7 +40,16 @@ namespace USca_Trending.Tags
                     {
                         // Get data...
                         var dtoJson = Encoding.ASCII.GetString(buffer, 0, result.Count);
-                        var socketMessage = JsonSerializer.Deserialize<SocketMessageDTO>(dtoJson);
+                        SocketMessageDTO? socketMessage;
+                        try
+                        {
+                            socketMessage = JsonSerializer.Deserialize<SocketMessageDTO>(dtoJson);
+                        }
+                        catch (JsonException)
+                        {
+                            // Probably failed to deserialize SocketMessageType, which is fine
+                            continue;
+                        }
                         if (socketMessage == null || socketMessage?.Type == null || socketMessage?.Message == null)
                         {
                             Console.WriteLine($"Strange socket message: {dtoJson}");

--- a/USca/USca_Trending/USca_Trending.csproj
+++ b/USca/USca_Trending/USca_Trending.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <TargetFramework>net7.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>


### PR DESCRIPTION
Closes #7, #9, #10

Main changes:
- Added `Alarm` and `AlarmLog` classes/tables
- Added ability to Add/Update/Delete Alarms from `DbManager`
- Refactored `TagTrendingWorker` (renamed to `TagWorker`). In the current architecture, `TagWorker` is a static class and is unreliant on web sockets. Instead, We have a `SocketWorker` class that runs the web socket loop and subscribes to the `RaiseWorkerEvent` of `TagWorker`. This way we can have multiple clients establish web sockets that read data from `TagWorker`. This was necesary because `TagWorker` has been expanded to check for alarm conditions; in the case a condition has been triggered, we invoke `RaiseWorkerEvent` and a `SocketWorker` instance listening to alarm triggers will pick the event up and send the information through the socket.
- `TagWorker` also saves the `AlarmLog` to the database and log file (alarmLog.txt)
- Added `AlarmDisplay` project. All it does is listen over the socket for triggered alarms and displays them in a list. The GUI is very primitive; if necessary we can expand it to color code the alarm logs and provide some filtering capabilities.

I have added a couple of alarms that should trigger pretty consistently. Look for the `Tank01_ValveIn` low priority alarm (should start firing almost immediately) and the `Tank01` medium priority alarm (fires after tank's level drops below 4.6, should take a couple of seconds)

Maybe I should implement additional alarm logic? For example, setting the triggered alarm as state for the tag instead of triggering (and persisting) the log over and over again, and then waiting until the alarm condition fails to write an "alarm ceased" log, or something like that.