### PR TITLE
Active alarm display

### DIFF
--- a/USca/DbManager/Alarms/AlarmDTO.cs
+++ b/USca/DbManager/Alarms/AlarmDTO.cs
@@ -1,13 +1,16 @@
 ﻿using System.ComponentModel;
+using System.Text.Json.Serialization;
 
 namespace USca_DbManager.Alarms
 {
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum AlarmThresholdType
     {
         BELOW, // Trigger alarm when value drops below threshold
         ABOVE, // Trigger alarm when value rises above threshold
     }
 
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum AlarmPriority
     {
         LOW,

--- a/USca/DbManager/Tags/TagAddDTO.cs
+++ b/USca/DbManager/Tags/TagAddDTO.cs
@@ -1,13 +1,17 @@
 ﻿using System.ComponentModel;
+using System.Text.Json.Serialization;
 
 namespace USca_DbManager.Tags
 {
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum TagMode
     {
         Input,
         Output
     }
 
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum TagType
     {
         Digital,

--- a/USca/USca-Server/Alarms/ActiveAlarmDTO.cs
+++ b/USca/USca-Server/Alarms/ActiveAlarmDTO.cs
@@ -1,0 +1,9 @@
+namespace USca_Server.Alarms
+{
+    public class ActiveAlarmDTO
+    {
+        public int AlarmId { get; set; }
+        public int TagId { get; set; }
+        public string? TagName { get; set; }
+    }
+}

--- a/USca/USca-Server/Alarms/ActiveAlarmDTO.cs
+++ b/USca/USca-Server/Alarms/ActiveAlarmDTO.cs
@@ -5,5 +5,6 @@ namespace USca_Server.Alarms
         public int AlarmId { get; set; }
         public int TagId { get; set; }
         public string? TagName { get; set; }
+        public AlarmPriority Priority { get; set; }
     }
 }

--- a/USca/USca-Server/Alarms/Alarm.cs
+++ b/USca/USca-Server/Alarms/Alarm.cs
@@ -4,12 +4,15 @@ using USca_Server.Tags;
 
 namespace USca_Server.Alarms
 {
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum AlarmThresholdType
     {
         BELOW, // Trigger alarm when value drops below threshold
         ABOVE, // Trigger alarm when value rises above threshold
     }
 
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum AlarmPriority
     {
         LOW,

--- a/USca/USca-Server/Alarms/Alarm.cs
+++ b/USca/USca-Server/Alarms/Alarm.cs
@@ -44,10 +44,11 @@ namespace USca_Server.Alarms
         public int TagId { get; set; }
         [JsonIgnore]
         public virtual Tag Tag { get; set; } = new();
+        public bool IsActive { get; set; }
 
         public override string ToString()
         {
-            return $"Alarm[Id={Id}, ThresholdType={ThresholdType}, Priority={Priority}, Threshold={Threshold}, TagId={TagId}]";
+            return $"Alarm[Id={Id}, ThresholdType={ThresholdType}, Priority={Priority}, Threshold={Threshold}, TagId={TagId}, IsActive={IsActive}]";
         }
 
         public bool ThresholdCrossed(double value)

--- a/USca/USca-Server/Alarms/AlarmController.cs
+++ b/USca/USca-Server/Alarms/AlarmController.cs
@@ -19,6 +19,12 @@ namespace USca_Server.Alarms
             return StatusCode(200, _alarmService.GetAll());
         }
 
+        [HttpGet("active")]
+        public ActionResult<List<ActiveAlarmDTO>> GetActiveAlarms()
+        {
+            return StatusCode(200, _alarmService.GetActive());
+        }
+
         [HttpDelete("{alarmId}")]
         public ActionResult DeleteAlarm(int alarmId)
         {

--- a/USca/USca-Server/Alarms/AlarmLog.cs
+++ b/USca/USca-Server/Alarms/AlarmLog.cs
@@ -11,14 +11,38 @@ namespace USca_Server.Alarms
         public AlarmPriority Priority { get; set; }
         public double Threshold { get; set; }
         public int TagId { get; set; }
+        public bool IsActive { get; set; }
         public string? TagName { get; set; }
         public int Address { get; set; }
-        public DateTime TimeStamp { get; set; }
+        public DateTime Timestamp { get; set; }
         public double RecordedValue { get; set; }
+
+        public static string ActiveStatus(bool status)
+        {
+            return status ? "activated" : "ceased";
+        }
+
+        public static string SignStatus(AlarmThresholdType Type, bool IsActive)
+        {
+            if (IsActive)
+            {
+                return Type.ToSign();
+            }
+            else
+            {
+                // Alarm has been deactivated, therefore the type/sign to display is reversed
+                return Type switch
+                {
+                    AlarmThresholdType.ABOVE => AlarmThresholdType.BELOW.ToSign(),
+                    AlarmThresholdType.BELOW => AlarmThresholdType.ABOVE.ToSign(),
+                    _ => throw new NotImplementedException()
+                };
+            }
+        }
 
         public static string LogEntry(AlarmLog log)
         {
-            return $"[{log.Priority} {log.TimeStamp}] Tag {log.TagId} ({log.TagName}) recorded alarm {log.AlarmId} at address {log.Address}: {log.RecordedValue:#.####} {log.ThresholdType.ToSign()} {log.Threshold:#.####}";
+            return $"[{log.Priority} {log.Timestamp}] Tag {log.TagId} ({log.TagName}) {ActiveStatus(log.IsActive)} alarm {log.AlarmId} at address {log.Address}: {log.RecordedValue:0.0000} {SignStatus(log.ThresholdType, log.IsActive)} {log.Threshold:0.0000}";
         }
     }
 }

--- a/USca/USca-Server/Alarms/AlarmService.cs
+++ b/USca/USca-Server/Alarms/AlarmService.cs
@@ -23,6 +23,7 @@ namespace USca_Server.Alarms
                 AlarmId = a.Id,
                 TagId = a.TagId,
                 TagName = a.Tag.Name,
+                Priority = a.Priority,
             }).ToList();
         }
 

--- a/USca/USca-Server/Alarms/AlarmService.cs
+++ b/USca/USca-Server/Alarms/AlarmService.cs
@@ -15,6 +15,17 @@ namespace USca_Server.Alarms
             return db.Alarms.Include(a => a.Tag).ToList();
         }
 
+        public List<ActiveAlarmDTO> GetActive()
+        {
+            using var db = new ServerDbContext();
+            return db.Alarms.Where(a => a.IsActive).Include(a => a.Tag).Select(a => new ActiveAlarmDTO()
+            {
+                AlarmId = a.Id,
+                TagId = a.TagId,
+                TagName = a.Tag.Name,
+            }).ToList();
+        }
+
         public void Delete(int alarmId)
         {
             using var db = new ServerDbContext();

--- a/USca/USca-Server/Alarms/IAlarmService.cs
+++ b/USca/USca-Server/Alarms/IAlarmService.cs
@@ -5,6 +5,7 @@ namespace USca_Server.Alarms
     public interface IAlarmService
     {
         public List<Alarm> GetAll();
+        public List<ActiveAlarmDTO> GetActive();
         public void Add(AlarmAddDTO alarmAddDTO);
         public void Update(AlarmUpdateDTO alarmUpdateDTO);
         public void Delete(int alarmId);

--- a/USca/USca-Server/Shared/ServerDbContext.cs
+++ b/USca/USca-Server/Shared/ServerDbContext.cs
@@ -234,32 +234,22 @@ namespace USca_Server.Shared
             Tags.Add(coolingTankCondenser03);
             Tags.Add(coolingTankCondenser04);
 
-            // TODO: Add alarms. Not all, but some. As a proof of concept, since it's tedious...
-            //Alarm a1 = new()
-            //{
-            //    ThresholdType = AlarmThresholdType.ABOVE,
-            //    Priority = AlarmPriority.HIGH,
-            //    Threshold = 9,
-            //    Tag = tag1,
-            //};
-            //Alarms.Add(a1);
-
-            //Alarm a2 = new()
-            //{
-            //    ThresholdType = AlarmThresholdType.BELOW,
-            //    Priority = AlarmPriority.MEDIUM,
-            //    Threshold = 4.6,
-            //    Tag = tag1,
-            //};
-            //Alarms.Add(a2);
-            //Alarm a3 = new()
-            //{
-            //    ThresholdType = AlarmThresholdType.ABOVE,
-            //    Priority = AlarmPriority.LOW,
-            //    Threshold = 0.0005,
-            //    Tag = tag2,
-            //};
-            //Alarms.Add(a3);
+            Alarms.Add(new()
+            {
+                ThresholdType = AlarmThresholdType.ABOVE,
+                Priority = AlarmPriority.HIGH,
+                Threshold = 5,
+                Tag = waterTank,
+                IsActive = false,
+            });
+            Alarms.Add(new()
+            {
+                ThresholdType = AlarmThresholdType.ABOVE,
+                Priority = AlarmPriority.MEDIUM,
+                Threshold = 1.7,
+                Tag = coolingTank,
+                IsActive = false,
+            });
 
             SaveChanges();
         }

--- a/USca/USca-Server/Shared/ServerDbContext.cs
+++ b/USca/USca-Server/Shared/ServerDbContext.cs
@@ -237,17 +237,25 @@ namespace USca_Server.Shared
             Alarms.Add(new()
             {
                 ThresholdType = AlarmThresholdType.ABOVE,
-                Priority = AlarmPriority.HIGH,
-                Threshold = 5,
-                Tag = waterTank,
+                Priority = AlarmPriority.MEDIUM,
+                Threshold = 1.7,
+                Tag = coolingTank,
                 IsActive = false,
             });
             Alarms.Add(new()
             {
                 ThresholdType = AlarmThresholdType.ABOVE,
                 Priority = AlarmPriority.MEDIUM,
-                Threshold = 1.7,
-                Tag = coolingTank,
+                Threshold = 5,
+                Tag = milkTank01,
+                IsActive = false,
+            });
+            Alarms.Add(new()
+            {
+                ThresholdType = AlarmThresholdType.BELOW,
+                Priority = AlarmPriority.HIGH,
+                Threshold = 1000000000,
+                Tag = milkTank02,
                 IsActive = false,
             });
 

--- a/USca/USca-Server/Tags/Tag.cs
+++ b/USca/USca-Server/Tags/Tag.cs
@@ -5,12 +5,16 @@ using USca_Server.Alarms;
 
 namespace USca_Server.Tags
 {
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum TagMode
     {
         Input,
         Output
     }
 
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum TagType
     {
         Digital,

--- a/USca/USca_AlarmDisplay/Alarm/ActiveAlarm.cs
+++ b/USca/USca_AlarmDisplay/Alarm/ActiveAlarm.cs
@@ -7,6 +7,7 @@ namespace USca_AlarmDisplay.Alarm
         public int AlarmId { get; set; }
         public int TagId { get; set; }
         public string? TagName { get; set; }
+        public AlarmPriority Priority { get; set; }
         public int MutedFor { get; set; } = 0;
         public bool IsMuted { get { return MutedFor > 0; } }
 
@@ -21,12 +22,14 @@ namespace USca_AlarmDisplay.Alarm
             TagId = other.TagId;
             TagName = other.TagName;
             MutedFor = other.MutedFor;
+            Priority = other.Priority;
         }
         public ActiveAlarm(AlarmLogDTO log)
         {
             AlarmId = log.AlarmId;
             TagId = log.TagId;
             TagName = log.TagName;
+            Priority = log.Priority;
         }
     }
 }

--- a/USca/USca_AlarmDisplay/Alarm/ActiveAlarm.cs
+++ b/USca/USca_AlarmDisplay/Alarm/ActiveAlarm.cs
@@ -1,0 +1,32 @@
+﻿using System.ComponentModel;
+
+namespace USca_AlarmDisplay.Alarm
+{
+    public partial class ActiveAlarm : INotifyPropertyChanged
+    {
+        public int AlarmId { get; set; }
+        public int TagId { get; set; }
+        public string? TagName { get; set; }
+        public int MutedFor { get; set; } = 0;
+        public bool IsMuted { get { return MutedFor > 0; } }
+
+        public ActiveAlarm()
+        {
+
+        }
+
+        public ActiveAlarm(ActiveAlarm other)
+        {
+            AlarmId = other.AlarmId;
+            TagId = other.TagId;
+            TagName = other.TagName;
+            MutedFor = other.MutedFor;
+        }
+        public ActiveAlarm(AlarmLogDTO log)
+        {
+            AlarmId = log.AlarmId;
+            TagId = log.TagId;
+            TagName = log.TagName;
+        }
+    }
+}

--- a/USca/USca_AlarmDisplay/Alarm/AlarmLogDTO.cs
+++ b/USca/USca_AlarmDisplay/Alarm/AlarmLogDTO.cs
@@ -36,15 +36,39 @@ namespace USca_AlarmDisplay.Alarm
         public AlarmThresholdType ThresholdType { get; set; }
         public AlarmPriority Priority { get; set; }
         public double Threshold { get; set; }
+        public bool IsActive { get; set; }
         public int TagId { get; set; }
         public string? TagName { get; set; }
         public int Address { get; set; }
-        public DateTime TimeStamp { get; set; }
+        public DateTime Timestamp { get; set; }
         public double RecordedValue { get; set; }
+
+        public static string ActiveStatus(bool status)
+        {
+            return status ? "activated" : "ceased";
+        }
+
+        public static string SignStatus(AlarmThresholdType Type, bool IsActive)
+        {
+            if (IsActive)
+            {
+                return Type.ToSign();
+            }
+            else
+            {
+                // Alarm has been deactivated, therefore the type/sign to display is reversed
+                return Type switch
+                {
+                    AlarmThresholdType.ABOVE => AlarmThresholdType.BELOW.ToSign(),
+                    AlarmThresholdType.BELOW => AlarmThresholdType.ABOVE.ToSign(),
+                    _ => throw new NotImplementedException()
+                };
+            }
+        }
 
         public static string LogEntry(AlarmLogDTO log)
         {
-            return $"[{log.Priority} {log.TimeStamp}] Tag {log.TagId} ({log.TagName}) recorded alarm {log.AlarmId} at address {log.Address}: {log.RecordedValue:#.####} {log.ThresholdType.ToSign()} {log.Threshold:#.####}";
+            return $"[{log.Priority} {log.Timestamp}] Tag {log.TagId} ({log.TagName}) {ActiveStatus(log.IsActive)} alarm {log.AlarmId} at address {log.Address}: {log.RecordedValue:0.0000} {SignStatus(log.ThresholdType, log.IsActive)} {log.Threshold:0.0000}";
         }
     }
 }

--- a/USca/USca_AlarmDisplay/Alarm/AlarmLogDTO.cs
+++ b/USca/USca_AlarmDisplay/Alarm/AlarmLogDTO.cs
@@ -1,14 +1,17 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Text.Json.Serialization;
 
 namespace USca_AlarmDisplay.Alarm
 {
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum AlarmThresholdType
     {
         BELOW, // Trigger alarm when value drops below threshold
         ABOVE, // Trigger alarm when value rises above threshold
     }
 
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum AlarmPriority
     {
         LOW,

--- a/USca/USca_AlarmDisplay/Alarm/AlarmService.cs
+++ b/USca/USca_AlarmDisplay/Alarm/AlarmService.cs
@@ -1,0 +1,33 @@
+﻿using RestSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Policy;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace USca_AlarmDisplay.Alarm
+{
+    internal class AlarmService
+    {
+        private static readonly string URL = "http://localhost:5274/api";
+        public static async Task<List<ActiveAlarm>> GetActiveAlarms()
+        {
+            using var cli = new RestClient(new RestClientOptions(URL));
+            var req = new RestRequest("alarm/active", Method.Get);
+            RestResponse response = await cli.ExecuteAsync(req);
+
+            if (response.StatusCode != System.Net.HttpStatusCode.OK)
+            {
+                throw new Exception(response.StatusCode.ToString());
+            }
+            if (response.Content == null)
+            {
+                return new();
+            }
+            var alarms = JsonSerializer.Deserialize<List<ActiveAlarm>>(response.Content);
+            return alarms ?? new();
+        }
+    }
+}

--- a/USca/USca_AlarmDisplay/AlarmAlerts.xaml
+++ b/USca/USca_AlarmDisplay/AlarmAlerts.xaml
@@ -13,6 +13,7 @@
     <Window.Resources>
         <local:AlarmLogDTOToCustomStringConverter x:Key="logConverter" />
         <local:ActiveAlarmToCustomStringConverter x:Key="activeAlarmConverter" />
+        <local:AlarmIsMutedToBoolConverter x:Key="alarmMutedConverter" />
     </Window.Resources>
     <Grid Margin="10">
         <Grid.RowDefinitions>
@@ -44,7 +45,17 @@
                     SelectionChanged="ListBox_SelectionChanged">
                     <ListBox.ItemTemplate>
                         <DataTemplate>
-                            <TextBlock Text="{Binding {}, Converter={StaticResource activeAlarmConverter}}" />
+                            <TextBlock Text="{Binding {}, Converter={StaticResource activeAlarmConverter}}">
+                                <TextBlock.Style>
+                                    <Style>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding {}, Converter={StaticResource ResourceKey=alarmMutedConverter}}" Value="false">
+                                                <Setter Property="TextBlock.Foreground" Value="Red" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                 </ListBox>

--- a/USca/USca_AlarmDisplay/AlarmAlerts.xaml
+++ b/USca/USca_AlarmDisplay/AlarmAlerts.xaml
@@ -2,6 +2,7 @@
     x:Class="USca_AlarmDisplay.AlarmAlerts"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:alarm="clr-namespace:USca_AlarmDisplay.Alarm"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:USca_AlarmDisplay"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -13,7 +14,8 @@
     <Window.Resources>
         <local:AlarmLogDTOToCustomStringConverter x:Key="logConverter" />
         <local:ActiveAlarmToCustomStringConverter x:Key="activeAlarmConverter" />
-        <local:AlarmIsMutedToBoolConverter x:Key="alarmMutedConverter" />
+        <local:AlarmSeverityToBoolConverter x:Key="alarmSeverityConverter" />
+        <local:AlarmActiveToBoolConverter x:Key="alarmActiveConverter" />
     </Window.Resources>
     <Grid Margin="10">
         <Grid.RowDefinitions>
@@ -27,7 +29,26 @@
             ItemsSource="{Binding AlarmLogs}">
             <ListBox.ItemTemplate>
                 <DataTemplate>
-                    <TextBlock Text="{Binding {}, Converter={StaticResource logConverter}}" />
+                    <TextBlock Text="{Binding {}, Converter={StaticResource logConverter}}">
+                        <TextBlock.Style>
+                            <Style>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding {}, Converter={StaticResource ResourceKey=alarmSeverityConverter}, ConverterParameter={x:Static alarm:AlarmPriority.HIGH}}" Value="true">
+                                        <Setter Property="TextBlock.Foreground" Value="Red" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding {}, Converter={StaticResource ResourceKey=alarmSeverityConverter}, ConverterParameter={x:Static alarm:AlarmPriority.MEDIUM}}" Value="true">
+                                        <Setter Property="TextBlock.Foreground" Value="DarkOrange" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding {}, Converter={StaticResource ResourceKey=alarmSeverityConverter}, ConverterParameter={x:Static alarm:AlarmPriority.LOW}}" Value="true">
+                                        <Setter Property="TextBlock.Foreground" Value="CornflowerBlue" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding {}, Converter={StaticResource ResourceKey=alarmActiveConverter}}" Value="false">
+                                        <Setter Property="TextBlock.Foreground" Value="Green" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>
@@ -49,8 +70,17 @@
                                 <TextBlock.Style>
                                     <Style>
                                         <Style.Triggers>
-                                            <DataTrigger Binding="{Binding {}, Converter={StaticResource ResourceKey=alarmMutedConverter}}" Value="false">
+                                            <DataTrigger Binding="{Binding {}, Converter={StaticResource ResourceKey=alarmSeverityConverter}, ConverterParameter={x:Static alarm:AlarmPriority.HIGH}}" Value="true">
                                                 <Setter Property="TextBlock.Foreground" Value="Red" />
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding {}, Converter={StaticResource ResourceKey=alarmSeverityConverter}, ConverterParameter={x:Static alarm:AlarmPriority.MEDIUM}}" Value="true">
+                                                <Setter Property="TextBlock.Foreground" Value="DarkOrange" />
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding {}, Converter={StaticResource ResourceKey=alarmSeverityConverter}, ConverterParameter={x:Static alarm:AlarmPriority.LOW}}" Value="true">
+                                                <Setter Property="TextBlock.Foreground" Value="CornflowerBlue" />
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding {}, Converter={StaticResource ResourceKey=alarmActiveConverter}}" Value="true">
+                                                <Setter Property="TextBlock.Foreground" Value="LightGray" />
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>

--- a/USca/USca_AlarmDisplay/AlarmAlerts.xaml
+++ b/USca/USca_AlarmDisplay/AlarmAlerts.xaml
@@ -9,7 +9,6 @@
     Width="800"
     Height="450"
     DataContext="{Binding RelativeSource={RelativeSource Self}}"
-    ResizeMode="NoResize"
     mc:Ignorable="d">
     <Window.Resources>
         <local:AlarmLogDTOToCustomStringConverter x:Key="logConverter" />
@@ -52,8 +51,8 @@
                 <StackPanel
                     x:Name="PanelMute"
                     Grid.Column="1"
-                    HorizontalAlignment="Right"
-                    VerticalAlignment="Center"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Top"
                     d:Visibility="Visible"
                     Visibility="Collapsed">
                     <StackPanel

--- a/USca/USca_AlarmDisplay/AlarmAlerts.xaml
+++ b/USca/USca_AlarmDisplay/AlarmAlerts.xaml
@@ -9,25 +9,86 @@
     Width="800"
     Height="450"
     DataContext="{Binding RelativeSource={RelativeSource Self}}"
+    ResizeMode="NoResize"
     mc:Ignorable="d">
     <Window.Resources>
         <local:AlarmLogDTOToCustomStringConverter x:Key="logConverter" />
+        <local:ActiveAlarmToCustomStringConverter x:Key="activeAlarmConverter" />
     </Window.Resources>
     <Grid Margin="10">
         <Grid.RowDefinitions>
-            <RowDefinition />
+            <RowDefinition Height="2*" />
+            <RowDefinition Height="*" />
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
-        <ListBox Grid.Row="0" ItemsSource="{Binding AlarmLogs}">
+        <ListBox
+            x:Name="LbLogs"
+            Grid.Row="0"
+            ItemsSource="{Binding AlarmLogs}">
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <TextBlock Text="{Binding {}, Converter={StaticResource logConverter}}" />
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>
+        <GroupBox Grid.Row="1" Header="Active alarms">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="2*" />
+                    <ColumnDefinition />
+                </Grid.ColumnDefinitions>
+                <ListBox
+                    x:Name="LbActiveAlarms"
+                    Grid.Column="0"
+                    ItemsSource="{Binding ActiveAlarms, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    SelectedItem="{Binding SelectedActiveAlarm, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    SelectionChanged="ListBox_SelectionChanged">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding {}, Converter={StaticResource activeAlarmConverter}}" />
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+                <StackPanel
+                    x:Name="PanelMute"
+                    Grid.Column="1"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Center"
+                    d:Visibility="Visible"
+                    Visibility="Collapsed">
+                    <StackPanel
+                        Margin="0,0,0,10"
+                        HorizontalAlignment="Right"
+                        Orientation="Horizontal">
+                        <Label x:Name="LblMute" Content="Mute alarm for" />
+                        <TextBox
+                            x:Name="TbSeconds"
+                            Width="100"
+                            VerticalContentAlignment="Center"
+                            PreviewTextInput="TbSeconds_PreviewTextInput"
+                            TextChanged="TbSeconds_TextChanged" />
+                        <Label Content="(s)" />
+                    </StackPanel>
+                    <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
+                        <Button
+                            x:Name="BtnMute"
+                            Width="80"
+                            Margin="0,0,10,0"
+                            Click="BtnMute_Click"
+                            Content="Mute" />
+                        <Button
+                            x:Name="BtnUnmute"
+                            Width="80"
+                            Click="BtnUnmute_Click"
+                            Content="Unmute" />
+                    </StackPanel>
+                </StackPanel>
+            </Grid>
+        </GroupBox>
         <Button
-            Grid.Row="1"
+            Grid.Row="2"
             Width="100"
+            Margin="0,10,0,0"
             HorizontalAlignment="Right"
             Click="BtnClear_Click"
             Content="Clear" />

--- a/USca/USca_AlarmDisplay/AlarmAlerts.xaml.cs
+++ b/USca/USca_AlarmDisplay/AlarmAlerts.xaml.cs
@@ -15,28 +15,6 @@ using System.Diagnostics;
 
 namespace USca_AlarmDisplay
 {
-    public partial class ActiveAlarm : INotifyPropertyChanged
-    {
-        public int AlarmId { get; set; }
-        public int TagId { get; set; }
-        public string? TagName { get; set; }
-        public int MutedFor { get; set; } = 0;
-        public bool IsMuted { get { return MutedFor > 0; } }
-
-        public ActiveAlarm(ActiveAlarm other)
-        {
-            AlarmId = other.AlarmId;
-            TagId = other.TagId;
-            TagName = other.TagName;
-            MutedFor = other.MutedFor;
-        }
-        public ActiveAlarm(AlarmLogDTO log)
-        {
-            AlarmId = log.AlarmId;
-            TagId = log.TagId;
-            TagName = log.TagName;
-        }
-    }
 
     public partial class AlarmAlerts : Window, INotifyPropertyChanged
     {
@@ -48,6 +26,14 @@ namespace USca_AlarmDisplay
         {
             InitializeComponent();
             OpenWebSocket();
+            LoadInitialActiveAlarms();
+        }
+
+        private async void LoadInitialActiveAlarms()
+        {
+            var activeAlarms = await AlarmService.GetActiveAlarms();
+            ActiveAlarms.Clear();
+            activeAlarms.ForEach(ActiveAlarms.Add);
         }
 
 

--- a/USca/USca_AlarmDisplay/AlarmAlerts.xaml.cs
+++ b/USca/USca_AlarmDisplay/AlarmAlerts.xaml.cs
@@ -125,7 +125,7 @@ namespace USca_AlarmDisplay
             {
                 ActiveAlarms.Add(new ActiveAlarm(log));
             }
-            else if (idx != -1)
+            else
             {
                 ActiveAlarms.RemoveAt(idx);
             }
@@ -154,7 +154,6 @@ namespace USca_AlarmDisplay
                 {
                     LblMute.IsEnabled = false;
                     TbSeconds.IsEnabled = false;
-                    BtnMute.IsEnabled = false;
                     BtnMute.IsEnabled = false;
                     BtnUnmute.IsEnabled = true;
                 }
@@ -193,11 +192,9 @@ namespace USca_AlarmDisplay
                     {
                         // ActiveAlarms doesn't seem to display alarm changes, so have to do this hack
                         // FIXME: Find something better? Why doesn't ActiveAlarms[idx] = alarm work?
-                        if (idx != -1)
-                        {
-                            var curSelectedIdx = LbActiveAlarms.SelectedIndex;
-                            UpdateActiveAlarmAt(idx, alarm, curSelectedIdx);
-                        }
+                        var curSelectedIdx = LbActiveAlarms.SelectedIndex;
+                        UpdateActiveAlarmAt(idx, alarm, curSelectedIdx);
+
                     });
                 }
             } catch
@@ -210,30 +207,33 @@ namespace USca_AlarmDisplay
 
         private void BtnMute_Click(object sender, RoutedEventArgs e)
         {
-            if (SelectedActiveAlarm != null)
+            if (SelectedActiveAlarm == null)
             {
-                int seconds = int.Parse(TbSeconds.Text);
-                SelectedActiveAlarm.MutedFor = seconds;
-                int alarmId = SelectedActiveAlarm.AlarmId;
-                int idx = ActiveAlarms.IndexOf(SelectedActiveAlarm);
-                var newAlarm = new ActiveAlarm(SelectedActiveAlarm);
-                UpdateActiveAlarmAt(idx, newAlarm, idx);
-                Thread thread = new(()=>Snooze(alarmId));
-                thread.Start();
-                TbSeconds.Text = "";
-                UpdateMuteDisplay();
+                return;
             }
+            int seconds = int.Parse(TbSeconds.Text);
+            SelectedActiveAlarm.MutedFor = seconds;
+            int alarmId = SelectedActiveAlarm.AlarmId;
+            int idx = ActiveAlarms.IndexOf(SelectedActiveAlarm);
+            // We make a copy because in UpdateActiveAlarmAt SelectedActiveAlarm will be set to null
+            var newAlarm = new ActiveAlarm(SelectedActiveAlarm);
+            UpdateActiveAlarmAt(idx, newAlarm, idx);
+            Thread thread = new(() => Snooze(alarmId));
+            thread.Start();
+            TbSeconds.Text = "";
+            UpdateMuteDisplay();
         }
 
         private void BtnUnmute_Click(object sender, RoutedEventArgs e)
         {
-            if (SelectedActiveAlarm != null)
+            if (SelectedActiveAlarm == null)
             {
-                SelectedActiveAlarm.MutedFor = 0;
-                int idx = ActiveAlarms.IndexOf(SelectedActiveAlarm);
-                var newAlarm = new ActiveAlarm(SelectedActiveAlarm);
-                UpdateActiveAlarmAt(idx, newAlarm, idx);
+                return;
             }
+            SelectedActiveAlarm.MutedFor = 0;
+            int idx = ActiveAlarms.IndexOf(SelectedActiveAlarm);
+            var newAlarm = new ActiveAlarm(SelectedActiveAlarm);
+            UpdateActiveAlarmAt(idx, newAlarm, idx);
         }
 
         private void UpdateActiveAlarmAt(int idx, ActiveAlarm alarm, int idxToSelect)

--- a/USca/USca_AlarmDisplay/AlarmAlerts.xaml.cs
+++ b/USca/USca_AlarmDisplay/AlarmAlerts.xaml.cs
@@ -282,4 +282,21 @@ namespace USca_AlarmDisplay
             return value;
         }
     }
+
+    public class AlarmIsMutedToBoolConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is ActiveAlarm alarm)
+            {
+                return alarm.IsMuted;
+            }
+            return value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value;
+        }
+    }
 }

--- a/USca/USca_AlarmDisplay/AlarmAlerts.xaml.cs
+++ b/USca/USca_AlarmDisplay/AlarmAlerts.xaml.cs
@@ -289,7 +289,6 @@ namespace USca_AlarmDisplay
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             AlarmPriority priority = (AlarmPriority)parameter;
-            Console.WriteLine($"{value.GetType()}, {value}");
             if (value is ActiveAlarm alarm)
             {
                 if (alarm.IsMuted)

--- a/USca/USca_AlarmDisplay/AlarmAlerts.xaml.cs
+++ b/USca/USca_AlarmDisplay/AlarmAlerts.xaml.cs
@@ -92,23 +92,7 @@ namespace USca_AlarmDisplay
             {
                 return;
             }
-            switch (log.Priority)
-            {
-                case AlarmPriority.LOW:
-                    AlarmLogs.Add(log);
-                    break;
-                case AlarmPriority.MEDIUM:
-                    AlarmLogs.Add(log);
-                    AlarmLogs.Add(log);
-                    break;
-                case AlarmPriority.HIGH:
-                    AlarmLogs.Add(log);
-                    AlarmLogs.Add(log);
-                    AlarmLogs.Add(log);
-                    break;
-                default:
-                    throw new NotImplementedException();
-            }
+            AlarmLogs.Add(log);
             LbLogs.ScrollIntoView(LbLogs.Items[^1]);
             var item = ActiveAlarms.FirstOrDefault(t => t.AlarmId == log.AlarmId);
             int idx = (item != null) ? ActiveAlarms.IndexOf(item) : -1;
@@ -272,7 +256,7 @@ namespace USca_AlarmDisplay
             }
             if (value is ActiveAlarm alarm)
             {
-                return $"Alarm {alarm.AlarmId} for tag {alarm.TagName}{muted(alarm)}";
+                return $"[{alarm.Priority}] Alarm {alarm.AlarmId} for {alarm.TagName}{muted(alarm)}";
             }
             return value;
         }
@@ -292,6 +276,64 @@ namespace USca_AlarmDisplay
                 return alarm.IsMuted;
             }
             return value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value;
+        }
+    }
+
+    public class AlarmSeverityToBoolConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            AlarmPriority priority = (AlarmPriority)parameter;
+            Console.WriteLine($"{value.GetType()}, {value}");
+            if (value is ActiveAlarm alarm)
+            {
+                if (alarm.IsMuted)
+                {
+                    return false;
+                }
+                return priority == alarm.Priority;
+            }
+            else if (value is AlarmLogDTO log)
+            {
+                if (!log.IsActive)
+                {
+                    return false;
+                }
+                return priority == log.Priority;
+            }
+            else
+            {
+                return value;
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value;
+        }
+    }
+
+    public class AlarmActiveToBoolConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is AlarmLogDTO log)
+            {
+                return log.IsActive;
+            }
+            else if (value is ActiveAlarm alarm)
+            {
+                return alarm.IsMuted;
+            }
+            else
+            {
+                return value;
+            }
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/USca/USca_AlarmDisplay/USca_AlarmDisplay.csproj
+++ b/USca/USca_AlarmDisplay/USca_AlarmDisplay.csproj
@@ -13,6 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="PropertyChanged.Fody" Version="4.1.0" />
+    <PackageReference Include="RestSharp" Version="110.2.0" />
   </ItemGroup>
 
 </Project>

--- a/USca/USca_RTU/Processor/SimulatorNew.cs
+++ b/USca/USca_RTU/Processor/SimulatorNew.cs
@@ -143,27 +143,27 @@ namespace USca_RTU.Processor
         {
             foreach (var o in Valves)
             {
-                o.Value += Math.Abs(r.NextDouble() * Math.Sin(DateTime.Now.Ticks / 5.0 + r.NextDouble() * 0.01) * 0.01);
+                o.Value += r.NextDouble() * Math.Sin(DateTime.Now.Ticks / 5.0 + r.NextDouble() * 0.01) * 0.01;
             }
 
             foreach (var o in ExternalValves)
             {
-                o.Value += Math.Abs(r.NextDouble() * Math.Sin(DateTime.Now.Ticks / 5.0 + r.NextDouble() * 0.01) * 0.01);
+                o.Value += r.NextDouble() * Math.Sin(DateTime.Now.Ticks / 5.0 + r.NextDouble() * 0.01) * 0.01;
             }
 
             foreach (var o in Condensers)
             {
-                o.Value += Math.Abs(r.NextDouble() * Math.Sin(DateTime.Now.Ticks / 5.0 + r.NextDouble() * 0.00001) * 0.00001);
+                o.Value += r.NextDouble() * Math.Sin(DateTime.Now.Ticks / 5.0 + r.NextDouble() * 0.00001) * 0.00001;
             }
 
             foreach (var o in HeatSources)
             {
-                o.Value += Math.Abs(r.NextDouble() * Math.Sin(DateTime.Now.Ticks / 5.0 + r.NextDouble() * 0.00001) * 0.00001);
+                o.Value += r.NextDouble() * Math.Sin(DateTime.Now.Ticks / 5.0 + r.NextDouble() * 0.00001) * 0.00001;
             }
 
             foreach (var o in Compressors)
             {
-                o.Value += Math.Abs(r.NextDouble() * Math.Sin(DateTime.Now.Ticks / 5.0 + r.NextDouble() * 0.001) * 0.001);
+                o.Value += r.NextDouble() * Math.Sin(DateTime.Now.Ticks / 5.0 + r.NextDouble() * 0.001) * 0.001;
             }
 
             foreach (var o in PressureBindings)

--- a/USca/USca_Trending/App.xaml
+++ b/USca/USca_Trending/App.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:USca_Trending"
-             StartupUri="MainWindow.xaml">
+             StartupUri="Tags/TagValues.xaml">
     <Application.Resources>
          
     </Application.Resources>

--- a/USca/USca_Trending/Tags/TagDTO.cs
+++ b/USca/USca_Trending/Tags/TagDTO.cs
@@ -1,13 +1,18 @@
 ﻿using System.ComponentModel;
+using System.Text.Json.Serialization;
 
 namespace USca_Trending.Tags
 {
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum TagMode
     {
         Input,
         Output
     }
 
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum TagType
     {
         Digital,

--- a/USca/USca_Trending/Tags/TagValues.xaml
+++ b/USca/USca_Trending/Tags/TagValues.xaml
@@ -1,10 +1,13 @@
-﻿<UserControl
+﻿<Window
     x:Class="USca_Trending.Tags.TagValues"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:USca_Trending.Tags"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	Title="USca Trending"
+	Height="450"
+	Width="800"
     d:DesignHeight="450"
     d:DesignWidth="800"
     DataContext="{Binding RelativeSource={RelativeSource Self}}"
@@ -67,4 +70,4 @@
             <DataGridTextColumn Binding="{Binding Timestamp}" Header="Timestamp" />
         </DataGrid.Columns>
     </DataGrid>
-</UserControl>
+</Window>

--- a/USca/USca_Trending/Tags/TagValues.xaml.cs
+++ b/USca/USca_Trending/Tags/TagValues.xaml.cs
@@ -9,10 +9,11 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Diagnostics;
 using USca_Trending.Util;
+using System.Windows;
 
 namespace USca_Trending.Tags
 {
-    public partial class TagValues : UserControl
+    public partial class TagValues : Window
     {
         public ObservableCollection<InputTagReadingDTO> TagReadings { get; set; } = new();
 


### PR DESCRIPTION
Closes #10
- Removed `Math.Abs()` from value calculations in the RTU. Idea was to prevent runaway values for tanks we're currently suffering from (the values only increase). This didn't work, but the original reason for why I added `Math.Abs()` was to prevent negative valve values, which doesn't seem to be a problem now either way? I kept the change since this is how the calculations were done at the start anyways
- Changed how alarms work. Alarms now have a `IsActive` field that determines whether logging will be done. If we cross a threshold but the alarm is already active, we don't log. If we don't cross a threshold but the alarm is active, we *do* log (alarm stopped being active).
- Expanded `AlarmAlerts` to show active alarms and mute/unmute them. Muting/unmuting is frontend-only and serves as eye candy. My thinking was that if we have several different clients running `USca_AlarmDisplay` at the same time they should all be able to independently decide if they want to mute/unmute alarms. The code is a little messy...
- Created three alarms for testing purposes. Two of the alarms will effectively be permanently active, for sake of testing the muting feature. Third one will flicker on and off.